### PR TITLE
Protected sigma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - opam install -y --verbose -j 1 coq-color
   - opam install -y --verbose -j 1 coq-ext-lib
   - opam install -y --verbose -j 1 coq-math-classes
-  - opam install -y --verbose -j 1 coq-metacoq-template
+  - opam install -y --verbose -j 1 coq-metacoq-template.1.0~beta1+8.12 && opam pin add coq-metacoq-template 1.0~beta1+8.12 -y
   - opam install -y --verbose -j 1 coq-switch
   - opam install -y --verbose -j 1 ANSITerminal
   - opam install -y --verbose -j 1 coq-flocq

--- a/coq/ASigmaHCOL/ReifyProofs.v
+++ b/coq/ASigmaHCOL/ReifyProofs.v
@@ -2217,7 +2217,7 @@ Global Instance Pointwise_MSH_DSH_compat
        {x_p y_p : PExpr}
        {σ : evalContext}
        {m : memory}
-       (FDF : MSH_DSH_IUnCarrierA_compat f σ df m)
+       (FDF : MSH_DSH_IUnCarrierA_compat f (protect_p σ y_p) df m)
        (P : DSH_pure (DSHIMap n x_p y_p df) y_p)
   :
     @MSH_DSH_compat _ _ (@MSHPointwise n f pF) (DSHIMap n x_p y_p df) σ m x_p y_p P.
@@ -2378,8 +2378,8 @@ Proof.
     *
       rewrite H, H1 in *.
       contradict Heqs3.
-      enough (T : is_Err (evalDSHIMap m (S n) df σ mx mb))
-        by (destruct (evalDSHIMap m (S n) df σ mx mb);
+      enough (T : is_Err (evalDSHIMap m (S n) df (protect_p σ y_p) mx mb))
+        by (destruct (evalDSHIMap m (S n) df (protect_p σ y_p) mx mb);
             [intros C; inl_inr | inversion T ]).
       apply evalDSHIMap_is_Err; try typeclasses eauto.
       lia.
@@ -2453,7 +2453,7 @@ Global Instance BinOp_MSH_DSH_compat
        {df : AExpr}
        {σ: evalContext}
        (m: memory)
-       (FDF : MSH_DSH_IBinCarrierA_compat f σ df m)
+       (FDF : MSH_DSH_IBinCarrierA_compat f (protect_p σ y_p) df m)
        (BP: DSH_pure (DSHBinOp o x_p y_p df) y_p)
   :
     @MSH_DSH_compat _ _ (MSHBinOp f) (DSHBinOp o x_p y_p df) σ m x_p y_p BP.
@@ -2625,8 +2625,8 @@ Proof.
     *
       contradict Heqs4.
       rewrite H, H1 in *.
-      enough (T : is_Err (evalDSHBinOp m (S o) (S o) df σ mx mb))
-        by (destruct (evalDSHBinOp m (S o) (S o) df σ mx mb);
+      enough (T : is_Err (evalDSHBinOp m (S o) (S o) df (protect_p σ y_p) mx mb))
+        by (destruct (evalDSHBinOp m (S o) (S o) df (protect_p σ y_p) mx mb);
             [intros C; inl_inr | inversion T ]).
       apply evalDSHBinOp_is_Err; try typeclasses eauto.
       lia.
@@ -2717,7 +2717,7 @@ Global Instance Inductor_MSH_DSH_compat
        {init : CarrierA}
        {a : AExpr}
        {x_p y_p : PExpr}
-       (FA : MSH_DSH_BinCarrierA_compat f σ a m)
+       (FA : MSH_DSH_BinCarrierA_compat f (protect_p σ y_p) a m)
        (PD : DSH_pure (DSHPower nx (x_p, NConst 0) (y_p, NConst 0) a init) y_p)
   :
     @MSH_DSH_compat _ _
@@ -3059,7 +3059,7 @@ Proof.
               cbn in Y_DMA; try inl_inr.
             inversion FA; clear FA;
               rename bin_equiv0 into FA; specialize (FA init xm'0 ).
-            destruct (evalBinCType m σ a init xm'0 ) as [|df] eqn:DF;
+            destruct (evalBinCType m (protect_p σ y_p) a init xm'0 ) as [|df] eqn:DF;
               try inl_inr; inl_inr_inv.
             (* abstract: this gets Y_DMA to "the previous step" for induction *)
             rewrite mem_add_overwrite in Y_DMA.
@@ -3399,7 +3399,7 @@ Global Instance IUnion_MSH_DSH_compat
            evalPExpr σ y_p ≡ inr (y_i, y_size) ->
            memory_equiv_except m m' y_i ->
            @MSH_DSH_compat _ _ (opf t) dop
-                           ((DSHnatVal (proj1_sig t)) :: σ)
+                           (((DSHnatVal (proj1_sig t)),false) :: σ)
                            m' (incrPVar 0 x_p) (incrPVar 0 y_p) DP)
   
 :
@@ -3436,7 +3436,7 @@ Proof.
       assert (T2: (∀ t m' y_i y_sz,
                       evalPExpr σ y_p ≡ inr (y_i, y_sz) ->
                       memory_equiv_except m m' y_i ->
-                      MSH_DSH_compat (opf' t) dop (DSHnatVal (proj1_sig t) :: σ) m'
+                      MSH_DSH_compat (opf' t) dop ((DSHnatVal (proj1_sig t),false) :: σ) m'
                                      (incrPVar 0 x_p) (incrPVar 0 y_p))).
       {
         clear - FC.
@@ -3474,7 +3474,7 @@ Proof.
       assert (T2: (∀ t m' y_i y_sz,
                       evalPExpr σ y_p ≡ inr (y_i, y_sz) ->
                       memory_equiv_except m m' y_i ->
-                      MSH_DSH_compat (opf' t) dop (DSHnatVal (proj1_sig t) :: σ) m'
+                      MSH_DSH_compat (opf' t) dop ((DSHnatVal (proj1_sig t),false) :: σ) m'
                                      (incrPVar 0 x_p) (incrPVar 0 y_p))).
       {
         clear - FC.
@@ -3522,7 +3522,7 @@ Proof.
       cbn in FC.
       inversion_clear FC as [F].
 
-      assert (T1 : lookup_PExpr_wsize (DSHnatVal n :: σ) loop_m (incrPVar 0 x_p) = inr (x_m, i)).
+      assert (T1 : lookup_PExpr_wsize ((DSHnatVal n,false) :: σ) loop_m (incrPVar 0 x_p) = inr (x_m, i)).
       {
         rewrite lookup_PExpr_wsize_incrPVar.
         clear - Heqo0 DP Y_M X_M XY YI.
@@ -3555,7 +3555,7 @@ Proof.
           reflexivity.
       }
 
-      assert (T2 : lookup_PExpr_wsize (DSHnatVal n :: σ) loop_m (incrPVar 0 y_p)
+      assert (T2 : lookup_PExpr_wsize ((DSHnatVal n,false) :: σ) loop_m (incrPVar 0 y_p)
                    = inr (y_lm, o)).
       {
         unfold lookup_PExpr_wsize in *.
@@ -3578,7 +3578,7 @@ Proof.
       specialize (F x_m y_lm T1 T2); clear T1 T2.
 
       rewrite evalDSHOperator_estimateFuel_ge by nia.
-      remember (evalDSHOperator (DSHnatVal n :: σ) dop loop_m (estimateFuel dop)) as dm;
+      remember (evalDSHOperator ((DSHnatVal n,false) :: σ) dop loop_m (estimateFuel dop)) as dm;
         clear Heqdm.
       remember (mem_op (S_opf (mkFinNat (Nat.lt_succ_diag_r n))) x_m) as mmb;
         clear Heqmmb.
@@ -3673,7 +3673,7 @@ Proof.
     rename Heqo into E1, Heqo0 into E2.
     remember (memory_next_key m0) as t_i.
     remember (memory_set m0 t_i mem_empty) as m1.
-    remember (DSHPtrVal t_i n :: σ) as σ'.
+    remember ((DSHPtrVal t_i n,false) :: σ) as σ'.
     intros k ky.
 
 
@@ -3874,14 +3874,14 @@ Global Instance Compose_MSH_DSH_compat
          (P2: DSH_pure dop2 (PVar 0))
          (P1: DSH_pure dop1 (incrPVar 0 y_p))
          (C2: @MSH_DSH_compat _ _ mop2 dop2
-                              (DSHPtrVal (memory_next_key m) o2 :: σ)
+                              ((DSHPtrVal (memory_next_key m) o2,false) :: σ)
                               (memory_set m (memory_next_key m) mem_empty)
                               (incrPVar 0 x_p) (PVar 0)
                               P2
           )
          (C1: forall m'', memory_equiv_except m m'' (memory_next_key m) ->
                       @MSH_DSH_compat _ _ mop1 dop1
-                                     (DSHPtrVal (memory_next_key m) o2 :: σ)
+                                     ((DSHPtrVal (memory_next_key m) o2,false) :: σ)
                                      m''
                                      (PVar 0) (incrPVar 0 y_p) P1)
   :
@@ -3897,7 +3897,7 @@ Proof.
   simpl.
 
   remember (memory_next_key m) as t_i.
-  remember (DSHPtrVal t_i o2 :: σ) as σ'.
+  remember ((DSHPtrVal t_i o2,false) :: σ) as σ'.
   remember (memory_set m t_i mem_empty) as m'.
 
   destruct (option_compose (mem_op mop1) (mem_op mop2) mx) as [md|] eqn:MD;
@@ -4190,7 +4190,7 @@ Proof.
       apply Option_equiv_eq in E2.
       specialize (mem_write_safe2 _ _ _ _ E2).
 
-      assert(TS: evalPExpr (DSHPtrVal t_i o2 :: σ) (PVar 0) = inr (t_i, o2))
+      assert(TS: evalPExpr ((DSHPtrVal t_i o2,false) :: σ) (PVar 0) = inr (t_i, o2))
         by reflexivity.
       specialize (mem_write_safe2 _ _ TS).
 
@@ -4404,7 +4404,7 @@ Proof.
       apply Option_equiv_eq in E2.
       specialize (mem_write_safe2 _ _ _ _ E2).
 
-      assert(TS: evalPExpr (DSHPtrVal t_i o2 :: σ) (PVar 0) = inr (t_i, o2))
+      assert(TS: evalPExpr ((DSHPtrVal t_i o2,false) :: σ) (PVar 0) = inr (t_i, o2))
         by reflexivity.
       specialize (mem_write_safe2 _ _ TS).
 
@@ -4623,7 +4623,7 @@ Proof.
       apply Option_equiv_eq in E2.
       specialize (mem_write_safe2 _ _ _ _ E2).
 
-      assert(TS: evalPExpr (DSHPtrVal t_i o2 :: σ) (PVar 0) = inr (t_i, o2))
+      assert(TS: evalPExpr ((DSHPtrVal t_i o2,false) :: σ) (PVar 0) = inr (t_i, o2))
         by reflexivity.
       specialize (mem_write_safe2 _ _ TS).
 
@@ -4923,7 +4923,7 @@ Proof.
         apply Option_equiv_eq in E2.
         specialize (mem_write_safe2 _ _ _ _ E2).
         
-        assert(TS: evalPExpr (DSHPtrVal t_i o2 :: σ) (PVar 0) = inr (t_i, o2))
+        assert(TS: evalPExpr ((DSHPtrVal t_i o2,false) :: σ) (PVar 0) = inr (t_i, o2))
           by reflexivity.
         specialize (mem_write_safe2 _ _ TS).
         
@@ -5930,7 +5930,7 @@ Lemma DSHMap2_succeeds
       (D2 : forall k, k < o -> mem_in k x2_m)
 
       (dot : CarrierA -> CarrierA -> CarrierA)
-      (DC : MSH_DSH_BinCarrierA_compat dot σ df m)
+      (DC : MSH_DSH_BinCarrierA_compat dot (protect_p σ y_p) df m)
   :
     exists m', evalDSHOperator σ (DSHMemMap2 o x1_p x2_p y_p df) m
                     (estimateFuel (DSHMemMap2 o x1_p x2_p y_p df)) = Some (inr m').
@@ -6042,7 +6042,7 @@ Lemma MemMap2_merge_with_def
       (LX2 : lookup_PExpr σ m x2_p = inr x2_m)
       (LY : lookup_PExpr σ m y_p = inr y_m)
 
-      (DC : MSH_DSH_BinCarrierA_compat dot σ df m)
+      (DC : MSH_DSH_BinCarrierA_compat dot (protect_p σ y_p) df m)
   :
     evalDSHOperator σ (DSHMemMap2 o x1_p x2_p y_p df) m
                     (estimateFuel (DSHMemMap2 o x1_p x2_p y_p df)) = Some (inr m') ->
@@ -6111,7 +6111,7 @@ Lemma MemMap2_merge_with_def_firstn
       (D1 : forall k, k < o -> mem_in k x1_m)
       (D2 : forall k, k < o -> mem_in k x2_m)
 
-      (DC : MSH_DSH_BinCarrierA_compat dot σ df m)
+      (DC : MSH_DSH_BinCarrierA_compat dot (protect_p σ y_p) df m)
   :
     evalDSHOperator σ (DSHMemMap2 o x1_p x2_p y_p df) m
                     (estimateFuel (DSHMemMap2 o x1_p x2_p y_p df))
@@ -6493,11 +6493,11 @@ Lemma Alloc_Loop_step
       (σ : evalContext)
       (t_id : nat)
       (T_ID : t_id ≡ memory_next_key m)
-      (LoopN : evalDSHOperator (DSHPtrVal t_id o :: σ) (DSHLoop n body)
+      (LoopN : evalDSHOperator ((DSHPtrVal t_id o,false) :: σ) (DSHLoop n body)
                                (memory_set m t_id mem_empty)
                                (estimateFuel (DSHLoop n body))
                = Some (inr loopN_m))
-      (IterSN : evalDSHOperator (DSHnatVal n :: DSHPtrVal t_id o :: σ)
+      (IterSN : evalDSHOperator ((DSHnatVal n,false) :: (DSHPtrVal t_id o,false) :: σ)
                                 body
                                 loopN_m
                                 (estimateFuel body) = Some (inr iterSN_m))
@@ -6510,7 +6510,7 @@ Proof.
   rewrite <-T_ID.
   rewrite evalDSHOperator_estimateFuel_ge
     by (pose proof estimateFuel_positive body; cbn; nia).
-  destruct (evalDSHOperator (DSHPtrVal t_id o :: σ) (DSHLoop n body)
+  destruct (evalDSHOperator ((DSHPtrVal t_id o,false) :: σ) (DSHLoop n body)
                             (memory_set m t_id mem_empty) (estimateFuel (DSHLoop n body)))
            as [t|] eqn:LoopN'; [destruct t as [|loopN_m'] |];
     try some_none; some_inv; try inl_inr; inl_inr_inv.
@@ -6530,7 +6530,7 @@ Lemma Alloc_Loop_error1
       (t_id : nat)
       (T_ID : t_id ≡ memory_next_key m)
       (msg : string)
-      (LoopN : evalDSHOperator (DSHPtrVal t_id o :: σ) (DSHLoop n body)
+      (LoopN : evalDSHOperator ((DSHPtrVal t_id o,false) :: σ) (DSHLoop n body)
                                (memory_set m t_id mem_empty)
                                (estimateFuel (DSHLoop n body))
                = Some (inl msg))
@@ -6543,7 +6543,7 @@ Proof.
   rewrite <-T_ID.
   rewrite evalDSHOperator_estimateFuel_ge
     by (pose proof estimateFuel_positive body; cbn; lia).
-  destruct (evalDSHOperator (DSHPtrVal t_id o :: σ) (DSHLoop n body)
+  destruct (evalDSHOperator ((DSHPtrVal t_id o,false) :: σ) (DSHLoop n body)
                             (memory_set m t_id mem_empty) (estimateFuel (DSHLoop n body)))
            as [t|] eqn:LoopN'; [destruct t as [|loopN_m'] |].
   - repeat constructor.
@@ -6559,11 +6559,11 @@ Lemma Alloc_Loop_error2
       (t_id : nat)
       (T_ID : t_id ≡ memory_next_key m)
       (msg : string)
-      (LoopN : evalDSHOperator (DSHPtrVal t_id o :: σ) (DSHLoop n body)
+      (LoopN : evalDSHOperator ((DSHPtrVal t_id o,false) :: σ) (DSHLoop n body)
                                (memory_set m t_id mem_empty)
                                (estimateFuel (DSHLoop n body))
                = Some (inr loopN_m))
-      (IterSN : evalDSHOperator (DSHnatVal n :: DSHPtrVal t_id o :: σ)
+      (IterSN : evalDSHOperator ((DSHnatVal n,false) :: (DSHPtrVal t_id o,false) :: σ)
                                 body
                                 loopN_m
                                 (estimateFuel body) = Some (inl msg))
@@ -6576,7 +6576,7 @@ Proof.
   rewrite <-T_ID.
   rewrite evalDSHOperator_estimateFuel_ge
     by (pose proof estimateFuel_positive body; cbn; nia).
-  destruct (evalDSHOperator (DSHPtrVal t_id o :: σ) (DSHLoop n body)
+  destruct (evalDSHOperator ((DSHPtrVal t_id o,false) :: σ) (DSHLoop n body)
                             (memory_set m t_id mem_empty) (estimateFuel (DSHLoop n body)))
            as [t|] eqn:LoopN'; [destruct t as [|loopN_m'] |];
     try some_none; some_inv; try inl_inr; inl_inr_inv.
@@ -6595,7 +6595,7 @@ Lemma DSHAlloc_inv
       (T_ID : t_id ≡ memory_next_key m)
   :
     evalDSHOperator σ (DSHAlloc o dop) m (estimateFuel (DSHAlloc o dop)) = Some (inr rm) ->
-    exists m', evalDSHOperator (DSHPtrVal t_id o :: σ) dop (memory_set m t_id mem_empty)
+    exists m', evalDSHOperator ((DSHPtrVal t_id o,false) :: σ) dop (memory_set m t_id mem_empty)
                           (estimateFuel dop) = Some (inr m') /\
           rm = memory_remove m' t_id.
 Proof.
@@ -6685,7 +6685,7 @@ Lemma DSHLoop_invariant
       (P : memory -> Prop)
       (PP : Proper ((=) ==> iff) P)
       (body_inv : forall n m m', P m ->
-                            evalDSHOperator (DSHnatVal n :: σ) body m
+                            evalDSHOperator ((DSHnatVal n,false) :: σ) body m
                                             (estimateFuel body) = Some (inr m') ->
                             P m')
   :
@@ -6760,13 +6760,13 @@ Global Instance IReduction_MSH_DSH_compat_S
        (DC : forall m' y_id d1 d2,
            evalPExpr_id σ y_p ≡ inr y_id ->
            memory_subset_except y_id m m'  ->
-           MSH_DSH_BinCarrierA_compat dot (d1 :: d2 :: σ) df m')
+           MSH_DSH_BinCarrierA_compat dot (protect_p (d1 :: d2 :: σ) y_p) df m')
        (FC : forall m' tmpk t y_id mb,
            evalPExpr_id σ y_p ≡ inr y_id ->
            memory_subset_except y_id m m'  ->
            tmpk ≡ memory_next_key m ->
            @MSH_DSH_compat _ _ (op_family t) rr
-                           (DSHnatVal (proj1_sig t) :: DSHPtrVal tmpk o :: σ)
+                           ((DSHnatVal (proj1_sig t),false) :: (DSHPtrVal tmpk o,false) :: σ)
                            (memory_set m' tmpk mb)
                            (incrPVar 0 (incrPVar 0 x_p)) (PVar 1) P)
 
@@ -7033,7 +7033,7 @@ Proof.
           reflexivity.
       }
       assert (T : exists t_dm,
-                   lookup_PExpr (DSHnatVal 0 :: DSHPtrVal t_id o :: σ) dm (PVar 1) = inr t_dm);
+                   lookup_PExpr ((DSHnatVal 0,false) :: (DSHPtrVal t_id o,false) :: σ) dm (PVar 1) = inr t_dm);
         [| destruct T as [t_dm T_DM]].
       {
         cbn.
@@ -7068,10 +7068,10 @@ Proof.
         rewrite memory_lookup_memory_set_eq by congruence.
         reflexivity.
       }
-      assert (Y_ID_in_dm : evalPExpr (DSHnatVal 0 :: DSHPtrVal t_id 0 :: σ)
+      assert (Y_ID_in_dm : evalPExpr ((DSHnatVal 0,false) :: (DSHPtrVal t_id 0,false) :: σ)
                                     (incrPVar 0 (incrPVar 0 y_p)) = inr (y_id, o))
         by (repeat rewrite evalPExpr_incrPVar; rewrite Y_ID; reflexivity).
-      assert (Y_DM : lookup_PExpr (DSHnatVal 0 :: DSHPtrVal t_id o :: σ)
+      assert (Y_DM : lookup_PExpr ((DSHnatVal 0,false) :: (DSHPtrVal t_id o,false) :: σ)
                                dm (incrPVar 0 (incrPVar 0 y_p)) =
                      inr (mem_union (mem_const_block o init) y_m)).
       {
@@ -7084,7 +7084,7 @@ Proof.
         reflexivity.
       }
       assert (Dot_compat_dm : MSH_DSH_BinCarrierA_compat dot
-                                               (DSHnatVal 0 :: DSHPtrVal t_id o :: σ)
+                                               (protect_p ((DSHnatVal 0,false) :: (DSHPtrVal t_id o,false) :: σ) y_p)
                                                df dm);
         [| clear DC].
       {
@@ -7128,7 +7128,7 @@ Proof.
       * (* Map2 fails *)
         exfalso.
         eq_to_equiv.
-        enough (exists m', evalDSHOperator (DSHnatVal 0 :: DSHPtrVal t_id o :: σ)
+        enough (exists m', evalDSHOperator ((DSHnatVal 0,false) :: (DSHPtrVal t_id o,false) :: σ)
             (DSHMemMap2 o (incrPVar 0 (incrPVar 0 y_p)) (PVar 1)
                (incrPVar 0 (incrPVar 0 y_p)) df) dm
             (estimateFuel

--- a/coq/ASigmaHCOL/ReifyProofs.v
+++ b/coq/ASigmaHCOL/ReifyProofs.v
@@ -6760,7 +6760,7 @@ Global Instance IReduction_MSH_DSH_compat_S
        (DC : forall m' y_id d1 d2,
            evalPExpr_id σ y_p ≡ inr y_id ->
            memory_subset_except y_id m m'  ->
-           MSH_DSH_BinCarrierA_compat dot (protect_p (d1 :: d2 :: σ) y_p) df m')
+           MSH_DSH_BinCarrierA_compat dot (protect_p (d1 :: d2 :: σ) (incrPVar 0 (incrPVar 0 y_p))) df m')
        (FC : forall m' tmpk t y_id mb,
            evalPExpr_id σ y_p ≡ inr y_id ->
            memory_subset_except y_id m m'  ->
@@ -7084,7 +7084,7 @@ Proof.
         reflexivity.
       }
       assert (Dot_compat_dm : MSH_DSH_BinCarrierA_compat dot
-                                               (protect_p ((DSHnatVal 0,false) :: (DSHPtrVal t_id o,false) :: σ) y_p)
+                                               (protect_p ((DSHnatVal 0,false) :: (DSHPtrVal t_id o,false) :: σ) (incrPVar 0 (incrPVar 0 y_p)) )
                                                df dm);
         [| clear DC].
       {
@@ -7288,7 +7288,7 @@ Proof.
             reflexivity.
       * (* Map2 runs out of fuel *)
         clear - Heqo0.
-        assert (is_Some (evalDSHOperator (DSHnatVal 0 :: DSHPtrVal t_id o :: σ)
+        assert (is_Some (evalDSHOperator ((DSHnatVal 0,false) :: (DSHPtrVal t_id o,false) :: σ)
             (DSHMemMap2 o (incrPVar 0 (incrPVar 0 y_p)) (PVar 1)
                (incrPVar 0 (incrPVar 0 y_p)) df) dm
             (estimateFuel
@@ -7786,7 +7786,7 @@ Proof.
         }
 
         assert (
-            evalDSHOperator (DSHnatVal n :: DSHPtrVal t_id o :: σ)
+            evalDSHOperator ((DSHnatVal n,false) :: (DSHPtrVal t_id o,false) :: σ)
                             (DSHMemMap2 o (incrPVar 0 (incrPVar 0 y_p)) (PVar 1)
                                         (incrPVar 0 (incrPVar 0 y_p)) df)
                             rr_m
@@ -8100,7 +8100,7 @@ Proof.
             rewrite Y_LoopNM in OPF_LoopN.
             inversion OPF_LoopN; subst x.
             
-            assert (T : lookup_PExpr (DSHnatVal n :: DSHPtrVal t_id o :: σ) rr_m (PVar 1)
+            assert (T : lookup_PExpr ((DSHnatVal n,false) :: (DSHPtrVal t_id o,false) :: σ) rr_m (PVar 1)
                         = inr t_rrm)
               by (cbn; unfold memory_lookup_err; rewrite T_RRM; reflexivity).
             rewrite T in R; clear T.

--- a/coq/ASigmaHCOL/ReifyProofs.v
+++ b/coq/ASigmaHCOL/ReifyProofs.v
@@ -1329,9 +1329,14 @@ Section BinCarrierA.
       assumption.
   Qed.
 
-  Lemma evalNExpr_cons_CTypeVal (a b : CarrierA) (σ1 σ2 : evalContext) (n : NExpr) :
+  Lemma evalNExpr_cons_CTypeVal
+        (a b : CarrierA)
+        (σ1 σ2 : evalContext)
+        (n : NExpr)
+        {f}
+    :
     (forall n', evalNExpr σ1 n' = evalNExpr σ2 n') ->
-    evalNExpr (DSHCTypeVal a :: σ1) n = evalNExpr (DSHCTypeVal b :: σ2) n.
+    evalNExpr ((DSHCTypeVal a,f) :: σ1) n = evalNExpr ((DSHCTypeVal b,f) :: σ2) n.
   Proof.
     intros.
     induction n.
@@ -1349,10 +1354,10 @@ Section BinCarrierA.
 
     (* inductive cases *)
     all: cbn.
-    all: destruct (evalNExpr (DSHCTypeVal a :: σ1) n1),
-                  (evalNExpr (DSHCTypeVal a :: σ1) n2),
-                  (evalNExpr (DSHCTypeVal b :: σ2) n1),
-                  (evalNExpr (DSHCTypeVal b :: σ2) n2); try inl_inr; try constructor.
+    all: destruct (evalNExpr ((DSHCTypeVal a,f) :: σ1) n1),
+                  (evalNExpr ((DSHCTypeVal a,f) :: σ1) n2),
+                  (evalNExpr ((DSHCTypeVal b,f) :: σ2) n1),
+                  (evalNExpr ((DSHCTypeVal b,f) :: σ2) n2); try inl_inr; try constructor.
     all: repeat inl_inr_inv; cbv in IHn1, IHn2; subst.
     all: try reflexivity.
     all: break_match; constructor.
@@ -1384,9 +1389,11 @@ Section BinCarrierA.
         (a b : CarrierA)
         (σ1 σ2 : evalContext)
         (mem: memory)
-        (m : MExpr) :
+        (m : MExpr)
+        {f}
+    :
     (forall m', evalMExpr mem σ1 m' = evalMExpr mem σ2 m') ->
-    evalMExpr mem (DSHCTypeVal a :: σ1) m = evalMExpr mem (DSHCTypeVal b :: σ2) m.
+    evalMExpr mem ((DSHCTypeVal a,f) :: σ1) m = evalMExpr mem ((DSHCTypeVal b,f) :: σ2) m.
   Proof.
     intros.
     destruct m as [[v] | t] ; [| reflexivity].
@@ -1817,8 +1824,8 @@ Proof.
     some_none.
 Qed.
 
-Lemma lookup_PExpr_wsize_incrPVar (foo : DSHVal) (σ : evalContext) (m : memory) (p : PExpr) :
-  lookup_PExpr_wsize (foo :: σ) m (incrPVar 0 p) ≡
+Lemma lookup_PExpr_wsize_incrPVar (foo : DSHVal) (σ : evalContext) (m : memory) (p : PExpr) {f} :
+  lookup_PExpr_wsize ((foo,f) :: σ) m (incrPVar 0 p) ≡
   lookup_PExpr_wsize σ m p.
 Proof.
   unfold lookup_PExpr_wsize.
@@ -1826,8 +1833,8 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma lookup_PExpr_incrPVar (foo : DSHVal) (σ : evalContext) (m : memory) (p : PExpr) :
-  lookup_PExpr (foo :: σ) m (incrPVar 0 p) ≡
+Lemma lookup_PExpr_incrPVar (foo : DSHVal) (σ : evalContext) (m : memory) (p : PExpr) {f}:
+  lookup_PExpr ((foo,f) :: σ) m (incrPVar 0 p) ≡
   lookup_PExpr σ m p.
 Proof.
   unfold lookup_PExpr.

--- a/coq/DSigmaHCOL/DSigmaHCOL.v
+++ b/coq/DSigmaHCOL/DSigmaHCOL.v
@@ -161,6 +161,12 @@ Module Type MDSigmaHCOL (Import CT: CType) (Import NT: NType).
         * rewrite Hp; auto.
   Qed.
 
+  Instance DSHVar_Setoid:
+    @Setoid DSHVal DSHVal_equiv.
+  Proof.
+    apply DSHVar_Equivalence.
+  Qed.
+
   Inductive NExpr_equiv: NExpr -> NExpr -> Prop :=
   | NVar_equiv  {n1 n2}: n1=n2 -> NExpr_equiv (NVar n1)  (NVar n2)
   | NConst_equiv {a b}: a=b -> NExpr_equiv (NConst a) (NConst b)

--- a/coq/DSigmaHCOL/DSigmaHCOLITree.v
+++ b/coq/DSigmaHCOL/DSigmaHCOLITree.v
@@ -110,12 +110,18 @@ Module MDSigmaHCOLITree
   Definition denotePExpr (σ: evalContext) (exp:PExpr): itree Event (nat*NT.t) :=
     lift_Serr (evalPExpr σ exp).
 
+  Definition denotePExpr' (σ: evalContext) (exp:PExpr): itree Event (nat*NT.t*bool) :=
+    lift_Serr (evalPExpr' σ exp).
+
   Definition denoteMExpr (σ: evalContext) (exp:MExpr): itree Event (mem_block*NT.t) :=
     match exp with
     | @MPtrDeref p =>
-      '(bi,size) <- denotePExpr σ p ;;
-      bi' <- trigger (MemLU "MPtrDeref" bi) ;;
-      ret (bi', size)
+      '(bi,size,f) <- denotePExpr' σ p ;;
+      if f:bool then
+        Sfail "Attempt to access protected variable in evalMExpr"
+      else
+        (bi' <- trigger (MemLU "MPtrDeref" bi) ;;
+         ret (bi', size))
     | @MConst t size => ret (t,size)
     end.
 
@@ -124,7 +130,7 @@ Module MDSigmaHCOLITree
   Fixpoint denoteNExpr (σ: evalContext) (e:NExpr): itree Event NT.t :=
     match e with
     | NVar i =>  lift_Serr
-                 (v <- (context_lookup "NVar not found" σ i) ;;
+                 ('(v,_) <- (context_lookup "NVar not found" σ i) ;;
                   (match v with
                    | DSHnatVal x => ret x
                    | _ => raise "invalid NVar type"
@@ -155,7 +161,7 @@ Module MDSigmaHCOLITree
   Fixpoint denoteAExpr (σ: evalContext) (e:AExpr): itree Event CT.t :=
     match e with
     | AVar i =>
-      v <- lift_Serr (context_lookup "AVar not found" σ i);;
+      '(v,_) <- lift_Serr (context_lookup "AVar not found" σ i);;
         (match v with
          | DSHCTypeVal x => ret x
          | _ => Sfail "invalid AVar type"
@@ -180,15 +186,15 @@ Module MDSigmaHCOLITree
 
   Definition denoteIUnCType (σ: evalContext) (f: AExpr)
              (i:NT.t) (a:CT.t): itree Event CT.t :=
-    denoteAExpr (DSHCTypeVal a :: DSHnatVal i :: σ) f.
+    denoteAExpr ((DSHCTypeVal a,false) :: (DSHnatVal i,false) :: σ) f.
 
   Definition denoteIBinCType (σ: evalContext) (f: AExpr)
              (i:NT.t) (a b:CT.t): itree Event CT.t :=
-    denoteAExpr (DSHCTypeVal b :: DSHCTypeVal a :: DSHnatVal i :: σ) f.
+    denoteAExpr ((DSHCTypeVal b,false) :: (DSHCTypeVal a,false) :: (DSHnatVal i,false) :: σ) f.
 
   Definition denoteBinCType (σ: evalContext) (f: AExpr)
              (a b:CT.t): itree Event CT.t :=
-    denoteAExpr (DSHCTypeVal b :: DSHCTypeVal a :: σ) f.
+    denoteAExpr ((DSHCTypeVal b,false) :: (DSHCTypeVal a,false) :: σ) f.
 
   Fixpoint denoteDSHIMap
            (n: nat)
@@ -277,7 +283,7 @@ Module MDSigmaHCOLITree
           '(y_i,y_sixe) <- denotePExpr σ y_p ;;
           x <- trigger (MemLU "Error looking up 'x' in DSHIMap" x_i) ;;
           y <- trigger (MemLU "Error looking up 'y' in DSHIMap" y_i) ;;
-          y' <- denoteDSHIMap n f σ x y ;;
+          y' <- denoteDSHIMap n f (protect_p σ y_p) x y ;;
           trigger (MemSet y_i y')
 
         | @DSHMemMap2 n x0_p x1_p y_p f =>
@@ -287,14 +293,14 @@ Module MDSigmaHCOLITree
           x0 <- trigger (MemLU "Error looking up 'x0' in DSHMemMap2" x0_i) ;;
           x1 <- trigger (MemLU "Error looking up 'x1' in DSHMemMap2" x1_i) ;;
           y <- trigger (MemLU "Error looking up 'y' in DSHMemMap2" y_i) ;;
-          y' <- denoteDSHMap2 n f σ x0 x1 y ;;
+          y' <- denoteDSHMap2 n f (protect_p σ y_p) x0 x1 y ;;
           trigger (MemSet y_i y')
         | @DSHBinOp n x_p y_p f =>
           '(x_i,x_size) <- denotePExpr σ x_p ;;
           '(y_i,y_sixe) <- denotePExpr σ y_p ;;
           x <- trigger (MemLU "Error looking up 'x' in DSHBinOp" x_i) ;;
           y <- trigger (MemLU "Error looking up 'y' in DSHBinOp" y_i) ;;
-          y' <- denoteDSHBinOp n n f σ x y ;;
+          y' <- denoteDSHBinOp n n f (protect_p σ y_p) x y ;;
           trigger (MemSet y_i y')
 
         | DSHPower ne (x_p,xoffset) (y_p,yoffset) f initial =>
@@ -306,7 +312,7 @@ Module MDSigmaHCOLITree
           xoff <- denoteNExpr σ xoffset ;;
           yoff <- denoteNExpr σ yoffset ;;
           let y' := mem_add (to_nat yoff) initial y in
-          y'' <- denoteDSHPower σ (to_nat n) f x y' (to_nat xoff) (to_nat yoff) ;;
+          y'' <- denoteDSHPower (protect_p σ y_p) (to_nat n) f x y' (to_nat xoff) (to_nat yoff) ;;
           trigger (MemSet y_i y'')
         | DSHLoop n body =>
           iter (fun (p: nat) =>
@@ -314,13 +320,13 @@ Module MDSigmaHCOLITree
                   then ret (inr tt)
                   else
                     vp <- lift_Serr (NT.from_nat p) ;;
-                    denoteDSHOperator (DSHnatVal vp :: σ) body ;; ret (inl (S p))
+                    denoteDSHOperator ((DSHnatVal vp,false) :: σ) body ;; ret (inl (S p))
                ) 0
 
         | DSHAlloc size body =>
           t_i <- trigger (MemAlloc size) ;;
           trigger (MemSet t_i (mem_empty)) ;;
-          denoteDSHOperator (DSHPtrVal t_i size :: σ) body ;;
+          denoteDSHOperator ((DSHPtrVal t_i size,false) :: σ) body ;;
           trigger (MemFree t_i)
 
         | DSHMemInit y_p value =>

--- a/coq/DSigmaHCOL/DSigmaHCOLITree.v
+++ b/coq/DSigmaHCOL/DSigmaHCOLITree.v
@@ -110,18 +110,12 @@ Module MDSigmaHCOLITree
   Definition denotePExpr (σ: evalContext) (exp:PExpr): itree Event (nat*NT.t) :=
     lift_Serr (evalPExpr σ exp).
 
-  Definition denotePExpr' (σ: evalContext) (exp:PExpr): itree Event (nat*NT.t*bool) :=
-    lift_Serr (evalPExpr' σ exp).
-
   Definition denoteMExpr (σ: evalContext) (exp:MExpr): itree Event (mem_block*NT.t) :=
     match exp with
     | @MPtrDeref p =>
-      '(bi,size,f) <- denotePExpr' σ p ;;
-      if f:bool then
-        Sfail "Attempt to access protected variable in evalMExpr"
-      else
-        (bi' <- trigger (MemLU "MPtrDeref" bi) ;;
-         ret (bi', size))
+      '(bi,size) <- denotePExpr σ p ;;
+      (bi' <- trigger (MemLU "MPtrDeref" bi) ;;
+       ret (bi', size))
     | @MConst t size => ret (t,size)
     end.
 

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -995,14 +995,14 @@ Section MSHCOL_to_AHCOL.
 
     Definition dynwin_σ_globals:evalContext :=
       [
-        DSHPtrVal dynwin_a_addr 3
+        (DSHPtrVal dynwin_a_addr 3,false)
       ].
 
     Definition dynwin_σ:evalContext :=
       dynwin_σ_globals ++
       [
-        DSHPtrVal dynwin_y_addr dynwin_o
-        ; DSHPtrVal dynwin_x_addr dynwin_i
+        (DSHPtrVal dynwin_y_addr dynwin_o,false)
+        ; (DSHPtrVal dynwin_x_addr dynwin_i,false)
       ].
 
     (* TODO: move, but not sure where. We do not have MemorySetoid.v *)

--- a/coq/LLVMGen/Correctness_Alloc.v
+++ b/coq/LLVMGen/Correctness_Alloc.v
@@ -38,13 +38,13 @@ Proof.
 Admitted.
 
 Lemma no_dshptr_aliasing_cons :
-  forall (memH : memoryH) (σ : evalContext) (size : Int64.int),
-    no_dshptr_aliasing (DSHPtrVal (memory_next_key memH) size :: σ) ->
+  forall (memH : memoryH) (σ : evalContext) (size : Int64.int) b,
+    no_dshptr_aliasing ((DSHPtrVal (memory_next_key memH) size , b):: σ) ->
     no_dshptr_aliasing σ.
 Proof.
   intros * st_no_dshptr_aliasing. repeat intro.
   specialize (st_no_dshptr_aliasing (S n) (S n')). cbn in *.
-  specialize (st_no_dshptr_aliasing _ _ _ H H0).
+  specialize (st_no_dshptr_aliasing _ _ _ _ _ H H0).
   inversion st_no_dshptr_aliasing. subst. reflexivity.
 Qed.
 
@@ -333,7 +333,7 @@ Proof.
     - cbn. intros. rewrite context_l0 in mem_is_inv.
       cbn in *. specialize (mem_is_inv (S n)). cbn in *.
       specialize (mem_is_inv _ _ _ H4 H5).
-      destruct v; eauto.
+      destruct v, d; eauto.
       destruct PRE.
       clear -mem_is_inv st_id_allocated st_id_allocated0 H4 H5.
 
@@ -362,7 +362,7 @@ Proof.
     - unfold no_dshptr_aliasing in *. intros.
       specialize (st_no_dshptr_aliasing (S n) (S n')).
       cbn in st_no_dshptr_aliasing.
-      specialize (st_no_dshptr_aliasing _ _ _ H4 H5).
+      specialize (st_no_dshptr_aliasing _ _ _ _ _ H4 H5).
       inv st_no_dshptr_aliasing. reflexivity.
     - unfold no_llvm_ptr_aliasing_cfg, no_llvm_ptr_aliasing in *.
       intros. cbn* in *.
@@ -377,9 +377,9 @@ Proof.
       intros.
 
       specialize (st_id_allocated (S n)). cbn in *.
-      specialize (st_id_allocated _ _ H4).
+      specialize (st_id_allocated _ _ _ H4).
       clear -st_id_allocated st_id_allocated0 H4.
-      specialize (st_id_allocated0 _ _ _ H4).
+      specialize (st_id_allocated0 _ _ _ _ H4).
       pose proof mem_block_exists_memory_next_key.
 
       rewrite <- mem_block_exists_memory_remove_neq. auto.

--- a/coq/LLVMGen/Correctness_Assign.v
+++ b/coq/LLVMGen/Correctness_Assign.v
@@ -122,18 +122,20 @@ Proof.
   intros RET _; eapply no_failure_helix_bind_continuation in NOFAIL; [| eassumption]; clear RET.
   destruct PRE0 as (PRE2 & [EXP2 EXT2 SCOPE2 VAR2 GAM2 MONO2]).
   cbn in *; inv_eqs.
+  (* simp; try_abs. *)
 
   hvred.
   break_inner_match_hyp; break_inner_match_hyp; try_abs.
   destruct_unit.
 
-  rename vH into src, vH0 into dst, b into v.
+  rename vH into src, vH0 into dst, b1 into v.
   clean_goal.
   (* Step 7. *)
   hvred.
   hstep.
   unfold assert_NT_lt,assert_true_to_err in *; simp.
   hide_cont.
+
   clear NOFAIL.
   rename i1 into vsz.
   rename i0 into vx_p, i3 into vy_p.
@@ -142,7 +144,10 @@ Proof.
 
   (* Question 1: is [vx_p] global, local, or can be either? *)
   (* We access in memory vx_p[e] *)
-  edestruct memory_invariant_Ptr as (membk & ptr & LU & FITS & INLG & GETCELL); [| eauto | eauto |]; eauto.
+
+  edestruct memory_invariant_Ptr as (membk & ptr & LU & FITS & INLG & GETCELL); [| eauto | eauto | |]; eauto.
+  admit.
+
   clear FITS.
 
   rewrite LU in H; symmetry in H; inv H.
@@ -187,7 +192,8 @@ Proof.
     { (* vy_p in global *)
       assert (Γ si ≡ Γ sf) as CONT by solve_gamma.
       rewrite CONT in LUn0, LUn.
-      edestruct memory_invariant_Ptr as (ymembk & yptr & yLU & yFITS & yINLG & yGETCELL); [| eapply Heqo0 | eapply LUn0 |]; [solve_state_invariant |].
+      edestruct memory_invariant_Ptr as (ymembk & yptr & yLU & yFITS & yINLG & yGETCELL); [| eapply Heqo0 | eapply LUn0 | |]; [solve_state_invariant | |].
+      admit.
 
       clean_goal.
       rewrite yLU in H0; symmetry in H0; inv H0.
@@ -316,19 +322,20 @@ Proof.
         split; [| split]; cbn.
         - (* State invariant *)
           cbn.
-          split; eauto.
+
           destruct PRE2.
+          split; eauto.
           unfold memory_invariant.
-          intros n1 v0 τ x0 H4 H5.
+          intros n1 v0 b τ x0 H4 H5.
           cbn in mem_is_inv.
-          pose proof (mem_is_inv n1 v0 τ x0 H4 H5).
+          pose proof (mem_is_inv n1 v0 b τ x0 H4 H5).
 
           (* TODO: can probably turn this into a lemma *)
           (* All depends on whether x0 == r, r1, or r0 *)
           destruct v0. destruct x0.
 
           { (* x0 is a global *)
-            destruct d.
+            (* destruct d. *)
             cbn. cbn in H4.
             { cbn in H. destruct H as (ptr_l & τ' & TYPE & INLG' & READ').
               do 2 eexists.

--- a/coq/LLVMGen/Correctness_Assign.v
+++ b/coq/LLVMGen/Correctness_Assign.v
@@ -325,9 +325,10 @@ Proof.
 
           (* TODO: can probably turn this into a lemma *)
           (* All depends on whether x0 == r, r1, or r0 *)
-          destruct x0.
+          destruct v0. destruct x0.
+
           { (* x0 is a global *)
-            destruct v0.
+            destruct d.
             cbn. cbn in H4.
             { cbn in H. destruct H as (ptr_l & τ' & TYPE & INLG' & READ').
               do 2 eexists.
@@ -368,7 +369,10 @@ Proof.
                 do 2 red. auto.
             }
 
-            { cbn in H. destruct H as (ptr_l & τ' & TYPE & INLG' & READ').
+
+          {
+            (* destruct x0. *)
+            cbn in H. destruct H as (ptr_l & τ' & TYPE & INLG' & READ').
               do 2 eexists.
               repeat split; eauto.
 
@@ -416,13 +420,13 @@ Proof.
               rewrite yLU in MLUP.
               inv MLUP.
 
-              epose proof (st_no_dshptr_aliasing _ _ _ _ _ Heqo0 H4); subst.
+              epose proof (st_no_dshptr_aliasing _ _ _ _ _ _ _ Heqo0 H4); subst.
               pose proof H5 as IDS.
               rewrite LUn0 in IDS.
               inv IDS.
 
               (* Since y_i = a, we know this matches the block that was written to *)
-              exists (mem_add (MInt64asNT.to_nat dst) v bk_h).
+              exists (mem_add (MInt64asNT.to_nat dst) b1 bk_h).
 
               (* *)
               exists yptr. exists (TYPE_Array sz0 TYPE_Double).
@@ -534,7 +538,7 @@ Proof.
             pose proof WRITE_SUCCEEDS as WRITE'.
             erewrite WRITE_ARRAY in WRITE_SUCCEEDS.
 
-            destruct v0. (* Probably need to use WF_IRState to make sure we only consider valid types *)
+            destruct d. (* Probably need to use WF_IRState to make sure we only consider valid types *)
             solve_in_local_or_global_scalar.
             solve_in_local_or_global_scalar.
 
@@ -543,7 +547,7 @@ Proof.
             - (* PTR aliases, local case should be bogus... *)
               subst.
 
-              epose proof (st_no_dshptr_aliasing _ _ _ _ _ Heqo0 H4); subst.
+              epose proof (st_no_dshptr_aliasing _ _ _ _ _ _ _ Heqo0 H4); subst.
               rewrite LUn0 in H5.
               inversion H5.
             - (* This is the branch where a and y_i don't *)
@@ -615,7 +619,7 @@ Proof.
             destruct PRE2.
 
             specialize (st_id_allocated n1). cbn in *.
-            specialize (st_id_allocated _ _ H).
+            specialize (st_id_allocated _ _ _ H).
             eapply mem_block_exists_memory_set; eauto.
         - exists bid_in. reflexivity.
 
@@ -765,6 +769,7 @@ Proof.
 
           assert (ID_Global id ≢ ID_Local vy_p) as IDNEQ by discriminate.
           destruct v0.
+          destruct d.
           - epose proof (mem_is_inv _ _ _ _ H H0) as INV.
             cbn in INV.
             cbn.
@@ -832,7 +837,7 @@ Proof.
             destruct INV as (bk & ptr_l & τ' & MLUP & TYP & FITS & LOOKUP & GETCELL_ptr_l).
 
             destruct (NPeano.Nat.eq_dec a y_i) as [ALIAS | NALIAS].
-            { exists (mem_add (MInt64asNT.to_nat dst) v ymembk). exists ptr_l. exists τ'.
+            { exists (mem_add (MInt64asNT.to_nat dst) b1 ymembk). exists ptr_l. exists τ'.
 
               subst.
               assert (n1 ≡ y_p) by eauto.
@@ -866,7 +871,7 @@ Proof.
         }
 
         { (* Local *)
-          destruct v0.
+          destruct v0. destruct d.
           - epose proof (mem_is_inv _ _ _ _ H H0) as INV.
             cbn in INV.
             eauto.
@@ -883,7 +888,7 @@ Proof.
             erewrite WRITE_ARRAY in WRITE_SUCCEEDS.
 
             destruct (NPeano.Nat.eq_dec a y_i) as [ALIAS | NALIAS].
-            { exists (mem_add (MInt64asNT.to_nat dst) v ymembk). exists ptr_l. exists τ'.
+            { exists (mem_add (MInt64asNT.to_nat dst) b1 ymembk). exists ptr_l. exists τ'.
 
               subst.
               assert (n1 ≡ y_p) by eauto.
@@ -944,9 +949,9 @@ Proof.
 
         { (* id_allocated *)
           unfold id_allocated in *.
-          intros n1 addr0 val H.
+          intros n1 addr0 val ? H.
           specialize (st_id_allocated n1). cbn in *.
-          specialize (st_id_allocated _ _ H).
+          specialize (st_id_allocated _ _ _ H).
           eapply mem_block_exists_memory_set; eauto.
         }
       - exists bid_in. reflexivity.
@@ -1148,7 +1153,7 @@ Proof.
         (* All depends on whether x0 == r, r1, or r0 *)
         destruct x0.
         { (* x0 is a global *)
-          destruct v0.
+          destruct v0. destruct d.
           cbn. cbn in H4.
           { cbn in H. destruct H as (ptr_l & τ' & TYPE & INLG' & READ').
             do 2 eexists.
@@ -1236,13 +1241,13 @@ Proof.
             rewrite yLU in MLUP.
             inv MLUP.
 
-            epose proof (st_no_dshptr_aliasing _ _ _ _ _ Heqo0 H4); subst.
+            epose proof (st_no_dshptr_aliasing _ _ _ _ _ _ _ Heqo0 H4); subst.
             pose proof H5 as IDS.
             rewrite LUn0 in IDS.
             inv IDS.
 
             (* Since y_i = a, we know this matches the block that was written to *)
-            exists (mem_add (MInt64asNT.to_nat dst) v bk_h).
+            exists (mem_add (MInt64asNT.to_nat dst) b1 bk_h).
 
             (* *)
             exists yptr. exists (TYPE_Array sz0 TYPE_Double).
@@ -1346,7 +1351,7 @@ Proof.
           pose proof WRITE_SUCCEEDS as WRITE'.
           erewrite WRITE_ARRAY in WRITE_SUCCEEDS.
 
-          destruct v0. (* Probably need to use WF_IRState to make sure we only consider valid types *)
+          destruct v0. (* Probably need to use WF_IRState to make sure we only consider valid types *) destruct d.
           solve_in_local_or_global_scalar.
           solve_in_local_or_global_scalar.
 
@@ -1355,7 +1360,7 @@ Proof.
           - (* PTR aliases, local case should be bogus... *)
             subst.
 
-            epose proof (st_no_dshptr_aliasing _ _ _ _ _ Heqo0 H4); subst.
+            epose proof (st_no_dshptr_aliasing _ _ _ _ _ _ _ Heqo0 H4); subst.
             rewrite LUn0 in H5.
             inversion H5.
           - (* This is the branch where a and y_i don't *)
@@ -1427,7 +1432,7 @@ Proof.
           destruct PRE2.
 
           specialize (st_id_allocated n1). cbn in *.
-          specialize (st_id_allocated _ _ H).
+          specialize (st_id_allocated _ _ _ H).
           eapply mem_block_exists_memory_set; eauto.
       - exists bid_in. reflexivity.
 
@@ -1577,7 +1582,7 @@ Proof.
 
 
           assert (ID_Global id ≢ ID_Local vy_p) as IDNEQ by discriminate.
-          destruct v0.
+          destruct v0. destruct d.
           - epose proof (mem_is_inv _ _ _ _ H H0) as INV.
             cbn in INV.
             cbn.
@@ -1644,7 +1649,7 @@ Proof.
             destruct INV as (bk & ptr_l & τ' & MLUP & TYP & FITS & LOOKUP & GETCELL_ptr_l).
 
             destruct (NPeano.Nat.eq_dec a y_i) as [ALIAS | NALIAS].
-            { exists (mem_add (MInt64asNT.to_nat dst) v ymembk). exists ptr_l. exists τ'.
+            { exists (mem_add (MInt64asNT.to_nat dst) b1 ymembk). exists ptr_l. exists τ'.
 
               subst.
               assert (n1 ≡ y_p) by eauto.
@@ -1678,7 +1683,7 @@ Proof.
         }
 
         { (* Local *)
-          destruct v0.
+          destruct v0. destruct d.
           - epose proof (mem_is_inv _ _ _ _ H H0) as INV.
             cbn in INV.
             eauto.
@@ -1695,7 +1700,7 @@ Proof.
             erewrite WRITE_ARRAY in WRITE_SUCCEEDS.
 
             destruct (NPeano.Nat.eq_dec a y_i) as [ALIAS | NALIAS].
-            { exists (mem_add (MInt64asNT.to_nat dst) v ymembk). exists ptr_l. exists τ'.
+            { exists (mem_add (MInt64asNT.to_nat dst) b1 ymembk). exists ptr_l. exists τ'.
 
               subst.
               assert (n1 ≡ y_p) by eauto.
@@ -1756,9 +1761,9 @@ Proof.
 
         { (* id_allocated *)
           unfold id_allocated in *.
-          intros n1 addr0 val H.
+          intros n1 addr0 val ? H.
           specialize (st_id_allocated n1). cbn in *.
-          specialize (st_id_allocated _ _ H).
+          specialize (st_id_allocated _ _ _ H).
           eapply mem_block_exists_memory_set; eauto.
         }
       - exists bid_in. reflexivity.

--- a/coq/LLVMGen/Correctness_IMap.v
+++ b/coq/LLVMGen/Correctness_IMap.v
@@ -163,8 +163,10 @@ Section DSHIMap_is_tfor.
     repeat (eapply eutt_clo_bind; [reflexivity|intros; try break_match_goal; subst]).
     setoid_rewrite denoteDSHIMap_as_tfor.
     rewrite eq_rev.
-    reflexivity.
-  Qed.
+  Admitted.
+
+  (*   reflexivity. *)
+  (* Qed. *)
 
 
 End DSHIMap_is_tfor.
@@ -185,12 +187,12 @@ Import AlistNotations.
 
 (* Yet another tweak at DSHCType *)
 Lemma state_invariant_enter_scope_DSHCType : 
-  forall σ v x s1 s2 stH mV l g,
+  forall σ v x s1 s2 stH mV l g b,
     Γ s2 ≡ (ID_Local x, TYPE_Double) :: Γ s1 ->
     ~ in_Gamma σ s1 x ->
     l @ x ≡ Some (UVALUE_Double v) ->
     state_invariant σ s1 stH (mV,(l,g)) ->
-    state_invariant (DSHCTypeVal v::σ) s2 stH (mV,(l,g)).
+    state_invariant ((DSHCTypeVal v, b)::σ) s2 stH (mV,(l,g)).
 Proof.
   intros * EQ GAM LU [MEM WF ALIAS1 ALIAS2 ALIAS3]; inv EQ; cbn in *.
   split.

--- a/coq/LLVMGen/Correctness_Loop.v
+++ b/coq/LLVMGen/Correctness_Loop.v
@@ -39,7 +39,7 @@ Section DSHLoop_is_tfor.
     denoteDSHOperator σ (DSHLoop n op)
                       ≈
                       tfor (fun p _ => vp <- lift_Serr (MInt64asNT.from_nat p) ;;
-                                    denoteDSHOperator (DSHnatVal vp :: σ) op) 0 n tt.
+                                    denoteDSHOperator ((DSHnatVal vp , false):: σ) op) 0 n tt.
   Proof.
     intros.
     unfold tfor.
@@ -66,7 +66,7 @@ Section DSHLoop_is_tfor.
                    tfor (fun k x => match x with
                                  | None => Ret None
                                  | Some (m',_) => interp_helix (vp <- lift_Serr (MInt64asNT.from_nat k) ;;
-                                                               denoteDSHOperator (DSHnatVal vp :: σ) op) m'
+                                                               denoteDSHOperator ((DSHnatVal vp, false):: σ) op) m'
                                  end)
                    0 n (Some (m, ())).
   Proof.
@@ -273,7 +273,7 @@ Proof.
       forward H; auto.
       rewrite EQk in H.
       apply no_failure_Ret in H.
-      auto.
+      eauto.
 
     - eapply eutt_mon, Heqs3.
       clear Heqs3 NOFAIL INPUTS_BETWEEN WFOCFG.

--- a/coq/LLVMGen/Correctness_MExpr.v
+++ b/coq/LLVMGen/Correctness_MExpr.v
@@ -57,13 +57,16 @@ Section MExpr.
 
     simp; try_abs. subst.
     hvred.
+    unfold lift_Serr in *.
+    simp; try_abs.
+    hvred.
+    cbn. hvred. cbn in NOFAIL.
+    rewrite bind_ret_l in NOFAIL.
+    simp; try_abs.
+    inv Heqs.
     edestruct memory_invariant_Ptr
       as (bkH & ptrV & Mem_LU & MEM & INLG & EQ); eauto.
     cbn.
-    hred.
-    unfold lift_Serr in NOFAIL. cbn in NOFAIL.
-    rewrite bind_ret_l in NOFAIL.
-    destruct b; try_abs.
     hred.
     hstep.
     solve_lu.

--- a/coq/LLVMGen/Correctness_MExpr.v
+++ b/coq/LLVMGen/Correctness_MExpr.v
@@ -12,6 +12,7 @@ Typeclasses Opaque equiv.
 
 Section MExpr.
 
+  Import ProofMode.
   Definition invariant_MExpr
              (e : exp typ) : Rel_cfg_T (mem_block * Int64.int) unit :=
     fun '(memH, (mb, mb_sz)) '(memV, (ρ, (g, _))) => 
@@ -50,12 +51,20 @@ Section MExpr.
   Proof.
     intros * Hgen INV NOFAIL.
     destruct mexp as [[vid] | mblock]; cbn* in Hgen; simp.
-    cbn.
+    (* cbn. *)
     unfold denoteMExpr, denotePExpr in *; cbn* in *.
-    simp; try_abs.
+    unfold denotePExpr', evalPExpr' in *.
+
+    simp; try_abs. subst.
     hvred.
     edestruct memory_invariant_Ptr
       as (bkH & ptrV & Mem_LU & MEM & INLG & EQ); eauto.
+    cbn.
+    hred.
+    unfold lift_Serr in NOFAIL. cbn in NOFAIL.
+    rewrite bind_ret_l in NOFAIL.
+    destruct b; try_abs.
+    hred.
     hstep.
     solve_lu.
     hvred.

--- a/coq/LLVMGen/Correctness_MemInit.v
+++ b/coq/LLVMGen/Correctness_MemInit.v
@@ -302,7 +302,7 @@ Proof.
     + Opaque memory_set.
       cbn; intros * LU1 LU2.
       eapply mem_is_inv in LU2; eauto.
-      destruct v; auto.
+      destruct v, d; auto.
       destruct LU2 as (? & ? & ? & ?).
       destruct (n =? a) eqn:EQ.
       * apply beq_nat_true in EQ; subst.

--- a/coq/LLVMGen/Correctness_Power.v
+++ b/coq/LLVMGen/Correctness_Power.v
@@ -146,8 +146,10 @@ Section DSHPower_is_tfor.
     cbn.
     repeat (eapply eutt_clo_bind; [reflexivity|intros; try break_match_goal; subst]).
     setoid_rewrite denoteDSHPower_as_tfor.
-    reflexivity.
-  Qed.
+  Admitted.
+
+  (*   reflexivity. *)
+  (* Qed. *)
 
   Lemma DSHPower_intepreted_as_tfor : forall σ ne x_p xoffset y_p yoffset f initial E m,
       interp_helix (E := E) (denoteDSHOperator σ (DSHPower ne (x_p,xoffset) (y_p,yoffset) f initial)) m

--- a/coq/LLVMGen/Correctness_Power.v
+++ b/coq/LLVMGen/Correctness_Power.v
@@ -442,9 +442,9 @@ Proof.
 
   pose proof state_invariant_memory_invariant PRE as MINV.
   unfold memory_invariant in MINV.
-  specialize (MINV n3 _ _ _ Heqo0 LUn0).
+  specialize (MINV n3 _ _ _ _ Heqo0 LUn0).
   cbn in MINV.
-  destruct MINV as (bkh & ptrll & τ' & MLUP & TEQ & FITS & INLG & GETARRAYCELL).
+  destruct MINV as (bkh & ptrll & τ' & MLUP & TEQ & FITS & INLG & GETARRAYCELL). admit.
   inv TEQ.
   destruct i3.
   { (* Global case *)

--- a/coq/LLVMGen/Correctness_Prelude.v
+++ b/coq/LLVMGen/Correctness_Prelude.v
@@ -169,13 +169,13 @@ Section EventTranslation.
       | DSHCType =>
         '(data,σ) <- denote_initFSHGlobals data gs ;;
         let '(x, data) := rotate Float64Zero data in
-         ret (data, (DSHCTypeVal x)::σ)
+         ret (data, (DSHCTypeVal x, false)::σ)
       | DSHPtr n =>
         '(data,σ) <- denote_initFSHGlobals data gs ;;
         let (data,mb) := constMemBlock (MInt64asNT.to_nat n) data in
         k <- trigger (MemAlloc n);;
         trigger (MemSet k mb);;
-        let p := DSHPtrVal k n in
+        let p := (DSHPtrVal k n,false) in
         ret (data, (p::σ))
       end
     end.
@@ -193,7 +193,7 @@ Section EventTranslation.
     let '(data, x) := constMemBlock (MInt64asNT.to_nat p.(i)) data in
     trigger (MemSet xindex x);;
 
-    let σ := List.app σ [DSHPtrVal yindex p.(o); DSHPtrVal xindex p.(i)] in
+    let σ := List.app σ [(DSHPtrVal yindex p.(o),false); (DSHPtrVal xindex p.(i),false)] in
     denoteDSHOperator σ (p.(Data.op) : DSHOperator);;
     bk <- trigger (MemLU "denote_FSHCOL" yindex);;
     lift_Derr (mem_to_list "Invalid output memory block" (MInt64asNT.to_nat p.(o)) bk).

--- a/coq/LLVMGen/Data.v
+++ b/coq/LLVMGen/Data.v
@@ -136,7 +136,7 @@ Qed.
 
 Definition initOneFSHGlobal
            (st: memory * list binary64)
-           (gp: string*DSHType) : err (memory * list binary64 * DSHVal)
+           (gp: string*DSHType) : err (memory * list binary64 * (DSHVal*bool))
   :=
     let (_,gt) := gp in
     let '(mem,data) := st in
@@ -145,15 +145,15 @@ Definition initOneFSHGlobal
       let '(x, data) := rotate Float64Zero data in
       let xz := bits_of_b64 x in (* a potential size overflow here ? *)
       xi <- MInt64asNT.from_Z xz ;;
-      ret (mem, data, DSHnatVal xi)
+      ret (mem, data, (DSHnatVal xi,false))
     | DSHCType =>
       let '(x, data) := rotate Float64Zero data in
-      ret (mem, data, DSHCTypeVal x)
+      ret (mem, data, (DSHCTypeVal x,false))
     | DSHPtr n =>
       let (data,mb) := constMemBlock (MInt64asNT.to_nat n) data in
       let k := memory_next_key mem in
       let mem := memory_set mem k mb in
-      let p := DSHPtrVal k n in
+      let p := (DSHPtrVal k n,false) in
       ret (mem, data, p)
     end.
 
@@ -180,7 +180,7 @@ Definition helix_initial_memory
        let Y_nat : nat := S (length globals) in
        let mem := memory_set mem Y_nat y in
        let mem := memory_set mem X_nat x in
-       let σ := globals_σ ++ [DSHPtrVal Y_nat o; DSHPtrVal X_nat i] in
+       let σ := globals_σ ++ [(DSHPtrVal Y_nat o,false); (DSHPtrVal X_nat i,false)] in
        ret (mem, data, σ)
      end.
 

--- a/coq/LLVMGen/EvalDenoteEquiv.v
+++ b/coq/LLVMGen/EvalDenoteEquiv.v
@@ -18,6 +18,7 @@ Section Eval_Denote_Equiv.
            (Ret (mem, (bk,size))).
   Proof.
     intros mem σ [] * EVAL; cbn* in *; simp; go; try reflexivity.
+    unfold denotePExpr'.
     rewrite Heqs; cbn*; go.
     reflexivity.
     cbn*; match_rewrite; reflexivity.
@@ -90,7 +91,7 @@ Section Eval_Denote_Equiv.
               then ret (inr tt)
               else
                 vp <- lift_Serr (from_nat p) ;;
-                denoteDSHOperator (DSHnatVal vp :: σ) body;;
+                denoteDSHOperator ((DSHnatVal vp , false):: σ) body;;
                 Ret (inl (S p))
            ) i.
 
@@ -128,7 +129,7 @@ Section Eval_Denote_Equiv.
               match from_nat N with
               | inl msg => Some (inl msg)
               | inr vN =>
-                evalDSHOperator (DSHnatVal vN :: σ) body mem fuel
+                evalDSHOperator ((DSHnatVal vN , false) :: σ) body mem fuel
               end
             | Some (inl msg) => Some (inl msg)
             | None => None
@@ -167,7 +168,7 @@ Section Eval_Denote_Equiv.
         from_nat i ≡ inr ii ->
         eval_Loop_for_i_to_N σ op i N mem_i fuel ≡ Some (inr mem_f) ->
         exists mem_aux,
-          evalDSHOperator (DSHnatVal ii :: σ) op mem_i fuel ≡ Some (inr mem_aux) /\
+          evalDSHOperator ((DSHnatVal ii , false) :: σ) op mem_i fuel ≡ Some (inr mem_aux) /\
           eval_Loop_for_i_to_N σ op (S i) N mem_aux fuel ≡ Some (inr mem_f).
     Proof.
       (* This proof is surprisingly painful to go through *)

--- a/coq/LLVMGen/Init.v
+++ b/coq/LLVMGen/Init.v
@@ -1232,7 +1232,7 @@ Lemma init_with_data_no_overwrite
       (m0 m : memoryH)
       (hdata0 hdata : list binary64)
       (globals : list (string * DSHType)) 
-      (e : list DSHVal)
+      (e : list (DSHVal * bool))
   :
     init_with_data initOneFSHGlobal no_chk (m0, hdata0) globals ≡ inr (m, hdata, e) →
     m = memory_union m0 m.
@@ -2514,8 +2514,10 @@ Proof.
 
         repeat break_match; try inl_inr.
         inversion IPOST; clear IPOST.
-        rename d into ne', l4 into e_post'.
-        subst p p1 p2 e_post.
+        subst.
+        (* rename d into ne', *)
+        rename l4 into e_post'.
+        (* subst p1 p2 e_post. *)
         destruct p0 as [mg0 hdata0].
 
         cbn.
@@ -2657,7 +2659,7 @@ Proof.
           copy_apply global_uniq_chk_preserves_st Heqs.
           subst i0.
 
-          rewrite GLOBALS in LG.
+          (* rewrite GLOBALS in LG. *)
           move LG at bottom.
           rewrite <-ListUtil.list_app_first_last in LG.
           apply initIRGlobals_inr in LG.
@@ -2670,9 +2672,9 @@ Proof.
             unfold alloc_glob_decl_inv_mcfg in H.
             intuition.
           ++
-            rewrite <-ListUtil.list_app_first_last in GLOBALS; assumption.
+            rewrite ListUtil.list_app_first_last. reflexivity.
           ++
-            rewrite <-ListUtil.list_app_first_last in GDECLS; eassumption.
+            rewrite ListUtil.list_app_first_last. reflexivity.
           ++
             (* [clear - PRE Heqs Heqs0.] doesn't work for some reason? *)
             clear IHpost; move PRE at bottom; move Heqs0 at bottom.
@@ -2806,8 +2808,8 @@ Proof.
             (fun '(memH, _) '(memV, (l, t1, (g, t2))) =>
                post_init_invariant
                  name
-                 (firstn (length globals) (e ++ [DSHPtrVal (S (Datatypes.length globals)) o;
-                        DSHPtrVal (Datatypes.length globals) i]))
+                 (firstn (length globals) (e ++ [(DSHPtrVal (S (Datatypes.length globals)) o, true);
+                        (DSHPtrVal (Datatypes.length globals) i, true)]))
                  {|
                    block_count := block_count;
                    local_count := local_count;
@@ -2872,7 +2874,7 @@ Proof.
               intros ? ? ? ? C.
               rewrite nth_error_nil in C.
               inversion C.
-            +
+            + repeat intro. destruct v.
               econstructor.
               rewrite nth_error_nil in H0.
               inversion H0.
@@ -2952,8 +2954,9 @@ Proof.
 
         repeat break_match; try inl_inr.
         inversion IPOST; clear IPOST.
-        rename d into ne', l4 into e_post'.
-        subst p p1 p2 e_post.
+        (* rename d into ne', *)
+        rename l4 into e_post'. subst.
+        (* subst p p1 p2 e_post. *)
         destruct p0 as [mg0 hdata0].
 
         rewrite translate_bind.
@@ -2983,7 +2986,7 @@ Proof.
 
           assert (exists v, Maps.lookup (g_ident tg2) g' ≡ Some v).
           {
-            subst globals.
+            (* subst globals. *)
             unfold allocated_globals in AG.
             cbn in *.
             unfold in_global_addr in AG.

--- a/coq/LLVMGen/Init.v
+++ b/coq/LLVMGen/Init.v
@@ -3080,7 +3080,7 @@ Proof.
             constructor.
             +
               cbn.
-              intros ? ? ? ? C.
+              intros ? ? ? ? ? C.
               rewrite nth_error_nil in C.
               inversion C.
             + repeat intro. destruct v.
@@ -3356,7 +3356,7 @@ Proof.
                   rewrite nth_error_app2 in H0 by reflexivity.
                   rewrite Nat.sub_diag in H0.
                   cbn in H0.
-                  some_inv; subst v.
+                  some_inv; subst.
                   move Heqs2 at bottom.
                   unfold initOneFSHGlobal in Heqs2.
                   cbn in Heqs2.


### PR DESCRIPTION
Descriptions copied from Slack for record keeping. This branch is a proposed fix to Bug 2 (See *Bugs in the compiler*).

## Bugs in the compiler
Quoting @YaZko :  
"Two bugs in the DHCOL to VIR compilation pass. Both bugs are present in both IMap and Power, let us consider Power to explain them.
The operator is of the shape Power n x y f where n is a nat, x and y are variables and f is an arithmetic expression and the intuitive semantics is meant to be y <- f^n(x)
To obtain this behavior, DHCOL read the vectors contained in memory at x and y and work over them in a purely functional style, leaving the memory untouched.
The VIR code it compiles to operates cell by cell in memory over the representation as structured data of the vector in y.
- Bug 1: a problem with aliasing. Suppose that x=y. The content of the entry vector is read at each iteration of the loop. On the Helix side, that means reading a pure vector passed as argument, so updates to the return vector y being computed has no effect. In contrast, for the compiled code, subsequent reads of x can now read an updated value since y is dynamically updated in memory.
- Bug 2: a problem with f depending on y. Suppose that the arithmetic operator implementing the mathematical function to be iterated. If it reads y as part of its behavior, then its semantics remains constant on the Helix side, but changes during the iterations on the generated code.
Arguably this is not a bug in the chain of compilation as a whole: Vadim states that both cases cannot happen in any DHCOL code produced. However no such invariant is enforce neither in the semantics of DHCOL, nor by the compiler, nor as a well-formedness precondition on DHCOL operators.
- As far as I’m concern, I believe that the correct approach should be to rule these behaviors out in the semantics of DHCOL. They are basically undefined behaviors, and the compiler has been written to assuming they can’t happen.
- Ruling them out statically as a precondition seems extremely hard.
- Out of better idea, we are trying to have the compiler fail in such cases.
- Bug 1: in the case of Power, an easy solution consists in pulling out the read to x from the loop, since it should read the same value everytime anyway. This solution however cannot apply to IMap. We are therefore adding a straight up equality test in the compiler to fail if x = y.
- Bug 2: the invariant we want to reflect is essentially for x and y (y most specifically) to not be in scope when compiling subexpressions of Power n x y f, i.e. prohibiting f from reading y. This should really be done at DHCOL level, pulling them out of σ, but once again we seem to not want to touch DHCOL... That makes things more complicated in that we cannot remove `x` and `y` from Γ in the compiler either, since this would completely break the memory invariant stating that variables in σ all find consistent variables in Γ. Instead, we are trying to taint these variables with a flag such that the compiler fails if it encounters a read to a flagged variable."


## Proposed Changes

Changes made by @vzaliva : 
"I have implemented "protected" flag for variables in Sigma. I confirm that this does not break any non-compiler proofs. Unit tests pass and DynWinProofs.v compiles."

Notes from @YaZko :
"We change the dynamic semantics of DHCOL to embed the invariants inherited by compilation by failing on the problematic cases.
For the aliasing bit, that means a dynamic equality check in evalDSHOperator for the imap, imap2, binop and power cases I believe.
For the other problem, that means fixing the scoping issue: in the imap, imap2, binop and power cases, when recursively evaluating f, it should be w.r.t. a a context σ from which x and y has been removed. To avoid fiddling with indexes, this is implemented by adding tags to variables in σ (σ: nat -> (value * bool)), and setting these tags to true before evaluating f. The removal of variables from the scopes is then enforced by updating the context_lookup used in the AVar case to fail if the variable looked up has its flag on."
