### PR TITLE
Rework of assumption classes and theorems related to translation between DHCOL-family languages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,12 +77,13 @@ pipeline {
             }
         }
 
-        stage('Build HELIX') {
+        stage('Build HELIX (end-to-end up to LLVM)') {
             steps {
                 script {
                     if (env.SKIP_CI != "true" && env.SKIP_BRANCH == "false") {
 			sh '''eval $(opam env)
-                              make -j ${NJOBS} test
+                              make Makefile.coq
+                              make -f Makefile.coq -j ${NJOBS} coq/DynWin/DynWinProofs.vo
                            '''
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
     def BUILD_IF_BRANCH = ['master','develop']
  */
 
-def BUILD_IF_BRANCH = ['master','ntype-ranges']
+def BUILD_IF_BRANCH = ['master','dshtranslator_class_rework']
 
 pipeline {
     agent { 

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -401,6 +401,21 @@ Module MDHCOLTypeTranslator
           ret (DSHSeq f' g')
         end.
 
+  Instance translate_runtime_memory_proper :
+    Proper ((=) ==> (=)) translate_runtime_memory.
+  Proof.
+  Admitted.
+
+  Instance translate_proper :
+    Proper ((=) ==> (=)) translate.
+  Proof.
+  Admitted.
+  
+  Instance translateEvalContext_proper :
+    Proper ((=) ==> (=)) translateEvalContext.
+  Proof.
+  Admitted.
+
   End EvalTranslations.
 
   Section Relations.
@@ -680,6 +695,10 @@ Module MDHCOLTypeTranslator
           rewrite <-H0,<-H1.
           apply H2.
     Qed.
+
+    Instance evalNExpr_closure_trace_equiv_proper :
+      Proper ((=) ==> (=) ==> (iff)) evalNExpr_closure_trace_equiv.
+    Admitted.
 
   End Relations.
 

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -165,7 +165,10 @@ Module MDHCOLTypeTranslator
 
     heq_NType_to_nat:
       forall x x', heq_NType x x' -> NT.to_nat x = NT'.to_nat x';
+    }.
 
+  Class NOpTranslationProps `{NTT: NTranslationOp} :=
+    {
     NTypeDiv_translation   : NBinOpTranslation NT.NTypeDiv   NT'.NTypeDiv  ;
     NTypeMod_translation   : NBinOpTranslation NT.NTypeMod   NT'.NTypeMod  ;
     NTypePlus_translation  : NBinOpTranslation NT.NTypePlus  NT'.NTypePlus ;
@@ -251,7 +254,10 @@ Module MDHCOLTypeTranslator
        Not sure if we need this
        translate_surj: forall (x':CT'.t), exists x, translateCTypeValue x = inr x';
      *)
+    }.
 
+  Class COpTranslationProps `{C: CTranslationOp} :=
+    {
     CTypePlus_translation  : CBinOpTranslation CT.CTypePlus  CT'.CTypePlus ;
     CTypeMult_translation  : CBinOpTranslation CT.CTypeMult  CT'.CTypeMult ;
     CTypeZLess_translation : CBinOpTranslation CT.CTypeZLess CT'.CTypeZLess;

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -237,8 +237,7 @@ Module MDHCOLTypeTranslator
 
   Section EvalTranslations.
 
-    Context `{CTT: CTranslationOp} (* `{CTP: @CTranslationProps CTT} *)
-            `{NTT: NTranslationOp}. (* `{NTP: @NTranslationProps NTT}. *)
+    Context `{CTT: CTranslationOp} `{NTT: NTranslationOp}.
 
     Import ListNotations.
 
@@ -686,7 +685,7 @@ Module MDHCOLTypeTranslator
   Section Necessary_NT_Props.
 
     Context `{NTT: NTranslationOp}.
-    Context `{NTP': @NTranslationProps' NTT}.
+    Context `{NTP: @NTranslationProps NTT}.
 
     Lemma from_nat_of_to_nat (nt : NT.t) :
       NT.from_nat (NT.to_nat nt) = inr nt.
@@ -762,7 +761,7 @@ Module MDHCOLTypeTranslator
       apply to_nat_of_from_nat in NT.
       apply to_nat_of_from_nat' in NT'.
       rewrite <-NT, <-NT'.
-      apply heq_NType_to_nat'.
+      apply heq_NType_to_nat.
       assumption.
     Qed.
 
@@ -781,7 +780,7 @@ Module MDHCOLTypeTranslator
 
       replace n' with n in *.
       2: {
-        apply heq_NType_to_nat' in SE.
+        apply heq_NType_to_nat in SE.
         apply err_equiv_eq in FSN, FSN'.
         apply to_nat_of_from_nat in FSN.
         apply to_nat_of_from_nat' in FSN'.
@@ -794,7 +793,7 @@ Module MDHCOLTypeTranslator
         [rename H into FN' | constructor].
       destruct FN as [nt FN], FN' as [nt' FN'].
 
-      clear - FN FN' NTP'.
+      clear - FN FN' NTP.
       pose proof heq_NType_from_nat n as E.
       inv E; try congruence.
       now constructor.
@@ -815,7 +814,7 @@ Module MDHCOLTypeTranslator
     Proof.
       intros A B.
       unfold LE.assert_NT_lt, LE'.assert_NT_lt.
-      apply heq_NType_to_nat' in A, B.
+      apply heq_NType_to_nat in A, B.
       cbv in A, B.
       rewrite !A, !B.
       destruct (Nat.ltb (to_nat a') (to_nat b')).
@@ -838,7 +837,7 @@ Module MDHCOLTypeTranslator
     Proof.
       intros A B.
       unfold LE.assert_NT_le, LE'.assert_NT_le.
-      apply heq_NType_to_nat' in A, B.
+      apply heq_NType_to_nat in A, B.
       cbv in A, B.
       rewrite !A, !B.
       destruct (Nat.leb (to_nat a') (to_nat b')).
@@ -1706,7 +1705,7 @@ Module MDHCOLTypeTranslator
   Section Value_Translation_Correctness'.
 
     Context `{CTT: CTranslationOp} `{NTT: NTranslationOp}
-            `{NTP': @NTranslationProps' NTT}.
+            `{NTP: @NTranslationProps NTT}.
 
     Lemma translateDSHVal_heq
           (d : L.DSHVal)
@@ -1729,8 +1728,8 @@ Module MDHCOLTypeTranslator
         autospecialize H; [reflexivity |].
         specialize (H t0 n0 H2).
         apply H.
-        clear - Heqs NTP'.
-        apply heq_NType_translateNTypeValue_compat'.
+        clear - Heqs NTP.
+        apply heq_NType_translateNTypeValue_compat.
         now rewrite Heqs.
       -
         repeat constructor.
@@ -1738,7 +1737,7 @@ Module MDHCOLTypeTranslator
         destruct H0.
         constructor.
         assumption.
-        apply heq_NType_translateNTypeValue_compat'.
+        apply heq_NType_translateNTypeValue_compat.
         rewrite Heqs; now f_equiv.
     Qed.
 
@@ -1769,7 +1768,7 @@ Module MDHCOLTypeTranslator
           destruct p; invc P.
           constructor.
           apply H0.
-          clear - H Heqs NTP'.
+          clear - H Heqs NTP.
           cbn in H.
 
           apply translateDSHVal_heq.
@@ -1787,7 +1786,7 @@ Module MDHCOLTypeTranslator
   Section Semantic_Translation_Correctness.
 
     Context `{CTT: CTranslationOp} `{NTT: NTranslationOp}.
-    Context `{NTP': NTranslationProps'}.
+    Context `{NTP: @NTranslationProps NTT}.
 
     Lemma heq_PExpr_heq_evalPExpr
           (heq : CT.t → CT'.t → Prop)
@@ -2356,7 +2355,7 @@ Module MDHCOLTypeTranslator
   Section ControlFlow_Translation_Correctness.
 
     Context `{NTT: NTranslationOp}.
-    Context `{NTP': NTranslationProps'}.
+    Context `{NTP: NTranslationProps}.
 
     Lemma translateNExpr_syntax
           (n : L.NExpr)
@@ -2386,7 +2385,7 @@ Module MDHCOLTypeTranslator
         autospecialize H; [reflexivity |].
         specialize (H t1 t2 H1).
         apply H.
-        clear - Heqs NTP'.
+        clear - Heqs NTP.
         apply heq_NType_translateNTypeConst_compat.
         rewrite Heqs; reflexivity.
     Qed.
@@ -2665,7 +2664,7 @@ Module MDHCOLTypeTranslator
         erewrite <-H8, <-H9; constructor.
         erewrite <-H7, <-H8.
         apply heq_mem_block_heq_mem_lookup_err.
-        now apply heq_NType_to_nat'.
+        now apply heq_NType_to_nat.
         eassumption.
       - (* AAbs *)
         apply IHAE in TE.
@@ -3412,7 +3411,7 @@ Module MDHCOLTypeTranslator
                (n:=NT.to_nat a1)
                (n':=NT'.to_nat b1)
           in H5;
-          [| apply heq_NType_to_nat'; assumption].
+          [| apply heq_NType_to_nat; assumption].
         inversion H5.
         constructor.
         repeat constructor.
@@ -3420,7 +3419,7 @@ Module MDHCOLTypeTranslator
           [assumption | reflexivity |].
         eapply heq_mem_block_mem_add.
         assumption.
-        now apply heq_NType_to_nat'.
+        now apply heq_NType_to_nat.
         constructor.
       - (* IMap *)
         repeat break_match; invc H3; invc H4.
@@ -3764,7 +3763,7 @@ Module MDHCOLTypeTranslator
         +
           apply heq_mem_block_mem_add.
           assumption.
-          apply heq_NType_to_nat'; assumption.
+          apply heq_NType_to_nat; assumption.
           constructor.
       - (* MemInit *)
         clear H0.
@@ -3795,7 +3794,7 @@ Module MDHCOLTypeTranslator
         apply heq_mem_block_heq_mem_union;
           [| assumption].
         apply heq_mem_const_block.
-        apply heq_NType_to_nat'; now invc H1.
+        apply heq_NType_to_nat; now invc H1.
         constructor.
       - (* Loop *)
         rename H0 into TΣN, H1 into TΣN';

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -170,6 +170,7 @@ Module MDHCOLTypeTranslator
         herr_f heq_NType (NT.from_nat n) (NT'.from_nat n);
     }.
 
+  (*
   Class NOpTranslationProps `{NTT: NTranslationOp} :=
     {
     NTypeDiv_translation   : NBinOpTranslation NT.NTypeDiv   NT'.NTypeDiv  ;
@@ -180,6 +181,7 @@ Module MDHCOLTypeTranslator
     NTypeMin_translation   : NBinOpTranslation NT.NTypeMin   NT'.NTypeMin  ;
     NTypeMax_translation   : NBinOpTranslation NT.NTypeMax   NT'.NTypeMax  ;
     }.
+   *)
 
   Class CBinOpTranslation
         `{CTranslationOp}
@@ -222,6 +224,7 @@ Module MDHCOLTypeTranslator
      *)
     }.
 
+  (*
   Class COpTranslationProps `{C: CTranslationOp} :=
     {
     CTypePlus_translation  : CBinOpTranslation CT.CTypePlus  CT'.CTypePlus ;
@@ -234,6 +237,7 @@ Module MDHCOLTypeTranslator
     CTypeNeg_translation: CUnOpTranslation CT.CTypeNeg CT'.CTypeNeg ;
     CTypeAbs_translation: CUnOpTranslation CT.CTypeAbs CT'.CTypeAbs ;
     }.
+   *)
 
   Section EvalTranslations.
 

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -166,18 +166,6 @@ Module MDHCOLTypeTranslator
               translateNTypeValue x = inr x';
     }.
 
-  Class NBinOpTranslation
-        `{NTranslationOp}
-        (f: NT.t -> NT.t -> NT.t)
-        (f': NT'.t -> NT'.t -> NT'.t)
-    :=
-      {
-    nbinop_translate_compat: forall x x' y y',
-          translateNTypeValue x = inr x' ->
-          translateNTypeValue y = inr y' ->
-          translateNTypeValue (f x y) = inr (f' x' y')
-      }.
-
   Class NTranslationProps `{NHE : NTranslation_heq} :=
     {
       heq_NType_to_nat :
@@ -188,18 +176,28 @@ Module MDHCOLTypeTranslator
         herr_f heq_NType (NT.from_nat n) (NT'.from_nat n);
     }.
 
-  (*
-  Class NOpTranslationProps `{NTT: NTranslationOp} :=
+  Class NBinOpTranslation
+        `{NHE : NTranslation_heq}
+        (f: NT.t -> NT.t -> NT.t)
+        (f': NT'.t -> NT'.t -> NT'.t)
+    :=
+      {
+        nbinop_translate_compat: forall x x' y y',
+          heq_NType x x' ->
+          heq_NType y y' ->
+          heq_NType (f x y) (f' x' y')
+      }.
+
+  Class NOpTranslationProps `{NTT: NTranslation_heq} :=
     {
-    NTypeDiv_translation   : NBinOpTranslation NT.NTypeDiv   NT'.NTypeDiv  ;
-    NTypeMod_translation   : NBinOpTranslation NT.NTypeMod   NT'.NTypeMod  ;
-    NTypePlus_translation  : NBinOpTranslation NT.NTypePlus  NT'.NTypePlus ;
-    NTypeMinus_translation : NBinOpTranslation NT.NTypeMinus NT'.NTypeMinus;
-    NTypeMult_translation  : NBinOpTranslation NT.NTypeMult  NT'.NTypeMult ;
-    NTypeMin_translation   : NBinOpTranslation NT.NTypeMin   NT'.NTypeMin  ;
-    NTypeMax_translation   : NBinOpTranslation NT.NTypeMax   NT'.NTypeMax  ;
+      NTypeDiv_translation   : NBinOpTranslation NT.NTypeDiv   NT'.NTypeDiv  ;
+      NTypeMod_translation   : NBinOpTranslation NT.NTypeMod   NT'.NTypeMod  ;
+      NTypePlus_translation  : NBinOpTranslation NT.NTypePlus  NT'.NTypePlus ;
+      NTypeMinus_translation : NBinOpTranslation NT.NTypeMinus NT'.NTypeMinus;
+      NTypeMult_translation  : NBinOpTranslation NT.NTypeMult  NT'.NTypeMult ;
+      NTypeMin_translation   : NBinOpTranslation NT.NTypeMin   NT'.NTypeMin  ;
+      NTypeMax_translation   : NBinOpTranslation NT.NTypeMax   NT'.NTypeMax  ;
     }.
-   *)
 
   Class CBinOpTranslation
         `{CHE : CTranslation_heq}
@@ -207,7 +205,7 @@ Module MDHCOLTypeTranslator
         (f': CT'.t -> CT'.t -> CT'.t)
     :=
       {
-        binop_translate_compat: forall x x' y y',
+        cbinop_translate_compat: forall x x' y y',
           heq_CType x x' ->
           heq_CType y y' ->
           heq_CType (f x y) (f' x' y')
@@ -219,7 +217,7 @@ Module MDHCOLTypeTranslator
         (f': CT'.t -> CT'.t)
     :=
       {
-        unop_translate_compat: forall x x',
+        cunop_translate_compat: forall x x',
           heq_CType x x' ->
           heq_CType (f x) (f' x')
       }.

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -401,16 +401,11 @@ Module MDHCOLTypeTranslator
 
   Section Relations.
 
-    Context `{CTT: CTranslationOp} `{NTT: NTranslationOp}.
-
-    (* [heq_CType] generalized *)
-    Variable heq_CConst : CT.t -> CT'.t -> Prop.
-
-    Hypothesis heq_CConst_proper :
-      Proper ((=) ==> (=) ==> (iff)) heq_CConst.
+    Context `{NHE : NTranslation_heq}
+            `{CHE : CTranslation_heq}.
 
     Definition heq_mem_block: L.mem_block -> L'.mem_block -> Prop :=
-      fun m m' => forall k : nat, hopt_r heq_CConst (LE.mem_lookup k m) (LE'.mem_lookup k m').
+      fun m m' => forall k : nat, hopt_r heq_CType (LE.mem_lookup k m) (LE'.mem_lookup k m').
 
     (* Check if two [nat]s translate successfully and to equivalent [NType] values *)
     Inductive heq_NT_nat: nat -> nat -> Prop :=
@@ -440,7 +435,7 @@ Module MDHCOLTypeTranslator
     | heq_AVar: forall x x', x=x' -> heq_AExpr (L.AVar x) (L'.AVar x')
     | heq_ANth: forall m m' n n', heq_MExpr m m' ->  heq_NExpr n n' -> heq_AExpr (L.ANth m n) (L'.ANth m' n')
     | heq_AAbs: forall x x', heq_AExpr x x' ->  heq_AExpr (L.AAbs x) (L'.AAbs x')
-    | heq_AConst: forall x x', heq_CConst x x' -> heq_AExpr (L.AConst x) (L'.AConst x')
+    | heq_AConst: forall x x', heq_CType x x' -> heq_AExpr (L.AConst x) (L'.AConst x')
     | heq_APlus : forall x y x' y', heq_AExpr x x' -> heq_AExpr y y' -> heq_AExpr (L.APlus x y) (L'.APlus x' y')
     | heq_AMinus : forall x y x' y', heq_AExpr x x' -> heq_AExpr y y' -> heq_AExpr (L.AMinus x y) (L'.AMinus x' y')
     | heq_AMult : forall x y x' y', heq_AExpr x x' -> heq_AExpr y y' -> heq_AExpr (L.AMult x y) (L'.AMult x' y')
@@ -489,7 +484,7 @@ Module MDHCOLTypeTranslator
           heq_PExpr src_p src_p' ->
           heq_PExpr dst_p dst_p' ->
           heq_AExpr f f' ->
-          heq_CConst ini ini' ->
+          heq_CType ini ini' ->
           heq_DSHOperator
             (L.DSHPower n (src_p,src_n) (dst_p, dst_n) f ini)
             (L'.DSHPower n' (src_p',src_n') (dst_p', dst_n') f' ini')
@@ -506,7 +501,7 @@ Module MDHCOLTypeTranslator
     | heq_DSHMemInit:
         forall p p' v v',
           heq_PExpr p p' ->
-          heq_CConst v v' ->
+          heq_CType v v' ->
           heq_DSHOperator (L.DSHMemInit p v) (L'.DSHMemInit p' v')
     | heq_DSHSeq:
         forall f f' g g',
@@ -516,7 +511,7 @@ Module MDHCOLTypeTranslator
 
     Inductive heq_DSHVal: LE.DSHVal -> LE'.DSHVal -> Prop :=
     | heq_DSHnatVal: forall x x', heq_NType x x' -> heq_DSHVal (LE.DSHnatVal x) (LE'.DSHnatVal x')
-    | heq_DSHCTypeVal: forall x x', heq_CConst x x' -> heq_DSHVal (LE.DSHCTypeVal x) (LE'.DSHCTypeVal x')
+    | heq_DSHCTypeVal: forall x x', heq_CType x x' -> heq_DSHVal (LE.DSHCTypeVal x) (LE'.DSHCTypeVal x')
     | heq_DSHPtrVal: forall a a' s s', a=a' -> heq_NType s s' -> heq_DSHVal (LE.DSHPtrVal a s) (LE'.DSHPtrVal a' s').
 
     Definition heq_evalContextElem : (LE.DSHVal * bool) -> (LE'.DSHVal * bool) -> Prop :=
@@ -573,13 +568,13 @@ Module MDHCOLTypeTranslator
       -
         destruct a,b,a',b'; invc H; inv Eb; inv Ea; constructor.
         + eapply heq_NType_proper; eauto; crush.
-        + eapply heq_CConst_proper; eauto; crush.
+        + eapply heq_CType_proper; eauto; crush.
         + crush.
         + eapply heq_NType_proper; eauto; crush.
       -
         destruct a,b,a',b'; invc H; inv Eb; inv Ea; constructor.
         + eapply heq_NType_proper; eauto; crush.
-        + eapply heq_CConst_proper; eauto; crush.
+        + eapply heq_CType_proper; eauto; crush.
         + crush.
         + eapply heq_NType_proper; eauto; crush.
     Qed.
@@ -608,7 +603,7 @@ Module MDHCOLTypeTranslator
           destruct (L.mem_lookup k a') eqn:H0';
             destruct (L'.mem_lookup k b') eqn:H1'; try constructor;
               repeat some_inv; try some_none.
-          eapply heq_CConst_proper;try symmetry; eauto.
+          eapply heq_CType_proper; try symmetry; eauto.
       -
         intros k.
         specialize (H k).
@@ -629,7 +624,7 @@ Module MDHCOLTypeTranslator
           destruct (L.mem_lookup k a) eqn:H0';
             destruct (L'.mem_lookup k b) eqn:H1'; try constructor;
               repeat some_inv; try some_none.
-          eapply heq_CConst_proper;try symmetry; eauto.
+          eapply heq_CType_proper; try symmetry; eauto.
     Qed.
 
     Instance heq_memory_proper:

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -793,7 +793,7 @@ Module MDHCOLTypeTranslator
       apply heq_NType_to_nat'.
       assumption.
     Qed.
-    
+
     Lemma heq_NT_nat_S (n n' : nat) :
       heq_NT_nat (S n) (S n') ->
       heq_NT_nat n n'.
@@ -821,7 +821,7 @@ Module MDHCOLTypeTranslator
       copy_apply (NT'.from_nat_lt (S n) snt' n) FSN';
         [rename H into FN' | constructor].
       destruct FN as [nt FN], FN' as [nt' FN'].
-      
+
       clear - FN FN' NTP'.
       pose proof heq_NType_from_nat n as E.
       inv E; try congruence.
@@ -2212,7 +2212,7 @@ Module MDHCOLTypeTranslator
           (n n' : nat)
           (mb : L.mem_block)
           (mb' : L'.mem_block)
-          (m : LE.memory) 
+          (m : LE.memory)
           (m' : memory)
       :
         heq_memory heq m m' ->
@@ -2334,7 +2334,7 @@ Module MDHCOLTypeTranslator
 
     Lemma heq_mem_block_heq_mem_union
           (heq : CT.t → CT'.t → Prop)
-          (mb1 mb2 : L.mem_block) 
+          (mb1 mb2 : L.mem_block)
           (mb1' mb2' : L'.mem_block)
       :
         heq_mem_block heq mb1 mb1' ->
@@ -2706,7 +2706,7 @@ Module MDHCOLTypeTranslator
     Lemma heq_AExpr_heq_evalIUnCType
           (m : L.memory)
           (m' : L'.memory)
-          (σ : LE.evalContext) 
+          (σ : LE.evalContext)
           (σ' : evalContext)
           (f : L.AExpr)
           (f' : L'.AExpr)
@@ -2744,7 +2744,7 @@ Module MDHCOLTypeTranslator
     Lemma heq_AExpr_heq_evalIBinCType
           (m : L.memory)
           (m' : L'.memory)
-          (σ : LE.evalContext) 
+          (σ : LE.evalContext)
           (σ' : evalContext)
           (f : L.AExpr)
           (f' : L'.AExpr)
@@ -2784,7 +2784,7 @@ Module MDHCOLTypeTranslator
     Lemma heq_AExpr_heq_evalBinCType
           (m : L.memory)
           (m' : L'.memory)
-          (σ : LE.evalContext) 
+          (σ : LE.evalContext)
           (σ' : evalContext)
           (f : L.AExpr)
           (f' : L'.AExpr)

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -149,6 +149,8 @@ Module MDHCOLTypeTranslator
           translateNTypeValue (f x y) = inr (f' x' y')
       }.
 
+  (* TODO: [translateNTypeValue] vs [translateNTypeConst].
+     Why have the first one? *)
   Class NTranslationProps `{NTT: NTranslationOp} :=
     {
     (* Value mapping should result in "equal" values *)
@@ -160,11 +162,12 @@ Module MDHCOLTypeTranslator
       forall x x', translateNTypeConst x = inr x' ->
               translateNTypeValue x = inr x';
 
-    (* So surjectivity property. This allows use for example map
-       natural numbers to signed integers *)
-
     heq_NType_to_nat:
       forall x x', heq_NType x x' -> NT.to_nat x = NT'.to_nat x';
+
+    heq_NType_from_nat :
+      forall n,
+        herr_f heq_NType (NT.from_nat n) (NT'.from_nat n);
     }.
 
   Class NOpTranslationProps `{NTT: NTranslationOp} :=
@@ -176,43 +179,6 @@ Module MDHCOLTypeTranslator
     NTypeMult_translation  : NBinOpTranslation NT.NTypeMult  NT'.NTypeMult ;
     NTypeMin_translation   : NBinOpTranslation NT.NTypeMin   NT'.NTypeMin  ;
     NTypeMax_translation   : NBinOpTranslation NT.NTypeMax   NT'.NTypeMax  ;
-    }.
-
-  (** * TODO: refine *)
-  (* This class imposes (almost) a subset of the restrictions of
-     [NTranslationProps] above. This is the minimal subset necessary to prove
-     the preservation of control flow (and therefore error handling) of an
-     operator over translation.
-
-     Full [NTranslationProps] could not be proven for the RHCOL->FHCOL
-     translation step (NType is translated as nat -> int64), but these
-     restrictions could. They are necessary and sufficient for RHCOL->FHCOL
-     control flow proofs.
-   *)
-  Class NTranslationProps' `{NTT : NTranslationOp} :=
-    {
-    (* exactly [heq_NType_to_nat] *)
-    heq_NType_to_nat' :
-      forall n n',
-        heq_NType n n' ->
-        NT.to_nat n = NT'.to_nat n';
-
-    (* The "inverse" of [heq_NType_to_nat] *)
-    (* TODO: this should be added to [NTranslationProps] at least *)
-    (* NOTE: [herr_f] vacuously holds if any argument is [inl]. In ohter words,
-             this is stating "If the same nat is *successfully* converted to
-             NType before and after translation, both NType values are
-             equivalent" *)
-    heq_NType_from_nat :
-      forall n,
-        herr_f heq_NType (NT.from_nat n) (NT'.from_nat n);
-
-    (* exactly [heq_NType_translateNTypeValue_compat] *)
-    (* Necessary for the the preservation of NType values in input [σ] *)
-    heq_NType_translateNTypeValue_compat' :
-      forall n n',
-        translateNTypeValue n = inr n' →
-        heq_NType n n';
     }.
 
   Class CBinOpTranslation

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -1484,7 +1484,7 @@ Module MDHCOLTypeTranslator
           subst.
 
           apply CTO.
-          apply CTO.
+          apply translateCTypeConst_translateCTypeValue_compat.
           symmetry in H.
           assumption.
         +
@@ -1616,7 +1616,6 @@ Module MDHCOLTypeTranslator
         heq_mem_block mb mb'.
     Proof.
       intros M.
-      unfold translate_runtime_memory in M.
       apply NM_err_sequence_inr_fun_spec in M.
 
       intros k.
@@ -1838,7 +1837,8 @@ Module MDHCOLTypeTranslator
         now constructor.
       -
         constructor.
-        apply CTO, CTO.
+        apply translateCTypeValue_heq_CType,
+          translateCTypeConst_translateCTypeValue_compat.
         rewrite Heqs.
         now f_equiv.
       -
@@ -1950,7 +1950,8 @@ Module MDHCOLTypeTranslator
           rewrite Heqs.
           now f_equiv.
         +
-          apply CTO, CTO.
+                  apply translateCTypeValue_heq_CType,
+          translateCTypeConst_translateCTypeValue_compat.
           rewrite Heqs0.
           now f_equiv.
       -
@@ -1975,7 +1976,8 @@ Module MDHCOLTypeTranslator
       -
         constructor.
         now apply translatePExpr_syntax.
-        apply CTO, CTO.
+        apply translateCTypeValue_heq_CType,
+          translateCTypeConst_translateCTypeValue_compat.
         rewrite Heqs.
         now f_equiv.
       -

--- a/coq/DSigmaHCOL/DSigmaHCOL.v
+++ b/coq/DSigmaHCOL/DSigmaHCOL.v
@@ -405,6 +405,10 @@ Module Type MDSigmaHCOL (Import CT: CType) (Import NT: NType).
 
   Instance DSHOperator_Equiv: Equiv DSHOperator  := DSHOperator_equiv.
 
+  Instance DSHOperator_equiv_Equivalence :
+    Equivalence DSHOperator_Equiv.
+  Admitted.
+
   Definition incrPVar (skip:nat) (p: PExpr): PExpr :=
     match p with
     | PVar var_id =>

--- a/coq/DSigmaHCOL/DSigmaHCOLEval.v
+++ b/coq/DSigmaHCOL/DSigmaHCOLEval.v
@@ -684,6 +684,72 @@ Module Type MDSigmaHCOLEval
     : option (err (list evalNatClosure)) :=
     intervalEvalDSHOperator (evalNatContext_of_evalContext σ) op cl fuel.
 
+  Lemma intervalEvalDSHOperator_fuel_monotone
+        (σn : evalNatContext)
+        (op : DSHOperator)
+        (σnc : list evalNatClosure) 
+        (fuel fuel' : nat)
+        r
+    :
+      fuel <= fuel' ->
+      intervalEvalDSHOperator σn op σnc fuel ≡ Some r ->
+      intervalEvalDSHOperator σn op σnc fuel' ≡ Some r.
+  Proof.
+    revert σn σnc fuel fuel' r.
+    induction op;
+      intros * F OK.
+    1-6,8-10: destruct fuel, fuel';
+      try assumption;
+      try lia;
+      try now inv OK.
+    -
+      cbn in *.
+      eapply IHop.
+      2: eassumption.
+      lia.
+    -
+      cbn in *.
+      repeat break_match_hyp; invc OK.
+      +
+        eapply IHop1 in Heqo.
+        erewrite Heqo.
+        reflexivity.
+        lia.
+      +
+        eapply IHop1 in Heqo.
+        rewrite Heqo.
+        erewrite IHop2.
+        symmetry; eassumption.
+        2: eassumption.
+        all: lia.
+    -
+      generalize dependent fuel.
+      generalize dependent fuel'.
+      revert r.
+      induction n;
+        intros * F OK.
+      all: destruct fuel, fuel';
+        try assumption;
+        try lia;
+        try now inv OK.
+      cbn; cbn in OK.
+      repeat break_match_hyp; invc OK; try reflexivity.
+      +
+        eapply IHn in Heqo.
+        erewrite Heqo.
+        reflexivity.
+        lia.
+      +
+        eapply IHn in Heqo.
+        erewrite Heqo.
+        rewrite H0.
+        eapply IHop in H0.
+        erewrite H0.
+        congruence.
+        lia.
+        lia.
+  Qed.
+
   Fixpoint evalDSHOperator
            (σ: evalContext)
            (op: DSHOperator)

--- a/coq/DSigmaHCOL/DSigmaHCOLEval.v
+++ b/coq/DSigmaHCOL/DSigmaHCOLEval.v
@@ -684,6 +684,22 @@ Module Type MDSigmaHCOLEval
     : option (err (list evalNatClosure)) :=
     intervalEvalDSHOperator (evalNatContext_of_evalContext σ) op cl fuel.
 
+  Instance evalNatClosure_Equiv :
+    Equiv evalNatClosure.
+  Admitted.
+
+  Instance evalNatClosure_Equivalence :
+    Equivalence evalNatClosure_Equiv.
+  Admitted.
+  
+  Instance intervalEvalDSHOperator_σ_proper :
+    Proper ((=) ==> (=) ==> (=) ==> (=) ==> (=)) intervalEvalDSHOperator_σ.
+  Admitted.
+
+  Instance estimateFuel_proper :
+    Proper ((=) ==> (=)) estimateFuel.
+  Admitted.
+
   Lemma intervalEvalDSHOperator_fuel_monotone
         (σn : evalNatContext)
         (op : DSHOperator)

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -2477,42 +2477,38 @@ Section TopLevel.
         (* Compile AHCOL -> RHCOL -> FHCOL *)
         AHCOLtoRHCOL.translate dynwin_AHCOL = inr dynwin_rhcol ->
         translate dynwin_rhcol = inr dynwin_fhcol ->
-
+        
         (* Compile memory *)
-        (AHCOLtoRHCOL.translate_runtime_memory (build_dynwin_memory a x) = inr dynwin_R_memory /\
-         RHCOLtoFHCOL.translate_runtime_memory dynwin_R_memory = inr dynwin_F_memory) ->
-
+        AHCOLtoRHCOL.translate_runtime_memory (build_dynwin_memory a x) = inr dynwin_R_memory ->
+        RHCOLtoFHCOL.translate_runtime_memory dynwin_R_memory = inr dynwin_F_memory ->
+        
         (* compile σ *)
-        (AHCOLtoRHCOL.translateEvalContext build_dynwin_σ = inr dynwin_R_σ /\
-         RHCOLtoFHCOL.translateEvalContext dynwin_R_σ = inr dynwin_F_σ) ->
+        AHCOLtoRHCOL.translateEvalContext build_dynwin_σ = inr dynwin_R_σ ->
+        RHCOLtoFHCOL.translateEvalContext dynwin_R_σ = inr dynwin_F_σ ->
+        
+        forall a_rmem x_rmem,
+          RHCOLEval.memory_lookup dynwin_R_memory dynwin_a_addr = Some a_rmem ->
+          RHCOLEval.memory_lookup dynwin_R_memory dynwin_x_addr = Some x_rmem ->
+          InConstr a_rmem x_rmem ->
 
-        (forall a_rmem x_rmem,
-            RHCOLEval.memory_lookup dynwin_R_memory dynwin_a_addr = Some a_rmem /\
-            RHCOLEval.memory_lookup dynwin_R_memory dynwin_x_addr = Some x_rmem /\
-            InConstr a_rmem x_rmem ->
+          (* Everything correct on Reals *)
+          exists r_omemory y_rmem,
+            RHCOLEval.evalDSHOperator
+              dynwin_R_σ
+              dynwin_rhcol
+              dynwin_R_memory
+              (RHCOLEval.estimateFuel dynwin_rhcol) = Some (inr r_omemory)
+            /\ RHCOLEval.memory_lookup r_omemory dynwin_y_addr = Some y_rmem
+            /\ AHCOLtoRHCOL.translate_runtime_mem_block (avector_to_mem_block y) = inr y_rmem
 
-            exists r_omemory,
-              RHCOLEval.evalDSHOperator
-                dynwin_R_σ
-                dynwin_rhcol
-                dynwin_R_memory
-                (RHCOLEval.estimateFuel dynwin_rhcol) = Some (inr r_omemory) ->
-
-              forall y_rmem,
-                RHCOLEval.memory_lookup r_omemory dynwin_y_addr = Some y_rmem ->
-
-                (* Everything correct on Reals *)
-                AHCOLtoRHCOL.translate_runtime_mem_block (avector_to_mem_block y) = inr y_rmem /\
-
-                (* And floats *)
-                exists f_omemory y_fmem,
-                  FHCOLEval.evalDSHOperator
-                    dynwin_F_σ dynwin_fhcol
-                    dynwin_F_memory
-                    (FHCOLEval.estimateFuel dynwin_fhcol) = (Some (inr f_omemory)) /\
-                  FHCOLEval.memory_lookup f_omemory dynwin_y_addr = Some y_fmem /\
-
-                  OutRel a_rmem x_rmem y_rmem y_fmem).
+            (* And floats *)
+            /\ exists f_omemory y_fmem,
+              FHCOLEval.evalDSHOperator
+                dynwin_F_σ dynwin_fhcol
+                dynwin_F_memory
+                (FHCOLEval.estimateFuel dynwin_fhcol) = (Some (inr f_omemory))
+              /\ FHCOLEval.memory_lookup f_omemory dynwin_y_addr = Some y_fmem
+              /\ OutRel a_rmem x_rmem y_rmem y_fmem.
   Proof.
     intros * HC * CA CR [CAM CRM] [CAE CRE] * [RA [RX C]].
 

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -1738,22 +1738,29 @@ Section TopLevel.
                             CarrierAplus CarrierAmult
                             CarrierAz CarrierA1
                             CarrierAle}.
-
+  (* TODO: instantiate? *)
   (* AHCOL -> RHCOL *)
   Context
     `{AR_CHE : AHCOLtoRHCOL.CTranslation_heq}
     `{AR_CTO : @AHCOLtoRHCOL.CTranslationOp AR_CHE}
     `{AR_NHE : AHCOLtoRHCOL.NTranslation_heq}
-    `{AR_NTO : @AHCOLtoRHCOL.NTranslationOp AR_NHE}.
+    `{AR_NTO : @AHCOLtoRHCOL.NTranslationOp AR_NHE}
+
+    `{AR_NTP : @AHCOLtoRHCOL.NTranslationProps AR_NHE}
+    `{AR_NOP : @AHCOLtoRHCOL.NOpTranslationProps AR_NHE}
+
+    `{AR_COP : @AHCOLtoRHCOL.COpTranslationProps AR_CHE}
+    `{AR_CTS : @AHCOLtoRHCOL.CTranslationOp_strict AR_CHE AR_CTO}.
 
   (* RHCOL -> FHCOL *)
   Context
     `{RF_CHE : RHCOLtoFHCOL.CTranslation_heq}
     `{RF_CTO : @RHCOLtoFHCOL.CTranslationOp RF_CHE}.
 
+  (* TODO: removing this was kind of a big deal *)
   (* We assuming that there is an injection of CType to Reals *)
-  Hypothesis AHCOLtoRHCOL_total :
-    forall c, exists r, AHCOLtoRHCOL.translateCTypeValue c ≡ inr r.
+  (* Hypothesis AHCOLtoRHCOL_total :
+    forall c, exists r, AHCOLtoRHCOL.translateCTypeValue c ≡ inr r. *)
 
 
   (* Initialize memory with X and placeholder for Y. *)
@@ -1778,408 +1785,6 @@ Section TopLevel.
                      (* x *) RHCOLEval.mem_block ->
                      (* y *) RHCOLEval.mem_block ->
                  (* y_mem *) FHCOLEval.mem_block -> Prop.
-
-  (** * RHCOL *)
-  Definition DynWin_RHCOL :=
-    RHCOLEval.DSHAlloc (NatAsNT.MNatAsNT.to_nat 2)
-      (RHCOLEval.DSHSeq
-         (RHCOLEval.DSHSeq
-            (RHCOLEval.DSHAlloc (NatAsNT.MNatAsNT.to_nat 1)
-               (RHCOLEval.DSHSeq
-                  (RHCOLEval.DSHSeq
-                     (RHCOLEval.DSHMemInit (RHCOL.PVar 0) MRasCT.CTypeZero)
-                     (RHCOLEval.DSHAlloc (NatAsNT.MNatAsNT.to_nat 1)
-                        (RHCOLEval.DSHLoop 3
-                           (RHCOLEval.DSHSeq
-                              (RHCOLEval.DSHAlloc (NatAsNT.MNatAsNT.to_nat 1)
-                                 (RHCOLEval.DSHSeq
-                                    (RHCOLEval.DSHAssign
-                                       (RHCOL.PVar (S (S (S (S (S (S 1)))))),
-                                       RHCOLEval.NConst
-                                         (NatAsNT.MNatAsNT.to_nat 0))
-                                       (RHCOL.PVar 0,
-                                       RHCOLEval.NConst
-                                         (NatAsNT.MNatAsNT.to_nat 0)))
-                                    (RHCOLEval.DSHAlloc
-                                       (NatAsNT.MNatAsNT.to_nat 1)
-                                       (RHCOLEval.DSHSeq
-                                          (RHCOLEval.DSHPower
-                                             (RHCOLEval.NVar 2)
-                                             (RHCOL.PVar (S 0),
-                                             RHCOLEval.NConst
-                                               (NatAsNT.MNatAsNT.to_nat 0))
-                                             (RHCOL.PVar 0,
-                                             RHCOLEval.NConst
-                                               (NatAsNT.MNatAsNT.to_nat 0))
-                                             (RHCOLEval.AMult
-                                                (RHCOLEval.AVar 1)
-                                                (RHCOLEval.AVar 0))
-                                             MRasCT.CTypeOne)
-                                          (RHCOLEval.DSHIMap 1
-                                             (RHCOL.PVar 0)
-                                             (RHCOL.PVar (S (S (S 0))))
-                                             (RHCOLEval.AMult
-                                                (RHCOLEval.AVar 0)
-                                                (RHCOLEval.ANth
-                                                   (RHCOLEval.MPtrDeref
-                                                   (RHCOL.PVar 8))
-                                                   (RHCOLEval.NVar 4))))))))
-                              (RHCOLEval.DSHMemMap2 1
-                                 (RHCOL.PVar (S (S 0)))
-                                 (RHCOL.PVar 1) (RHCOL.PVar (S (S 0)))
-                                 (RHCOLEval.APlus (RHCOLEval.AVar 1)
-                                    (RHCOLEval.AVar 0)))))))
-                  (RHCOLEval.DSHAssign
-                     (RHCOL.PVar 0,
-                     RHCOLEval.NConst (NatAsNT.MNatAsNT.to_nat 0))
-                     (RHCOL.PVar (S 0),
-                     RHCOLEval.NConst (NatAsNT.MNatAsNT.to_nat 0)))))
-            (RHCOLEval.DSHAlloc (NatAsNT.MNatAsNT.to_nat 1)
-               (RHCOLEval.DSHSeq
-                  (RHCOLEval.DSHSeq
-                     (RHCOLEval.DSHMemInit (RHCOL.PVar 0) MRasCT.CTypeZero)
-                     (RHCOLEval.DSHAlloc (NatAsNT.MNatAsNT.to_nat 1)
-                        (RHCOLEval.DSHLoop 2
-                           (RHCOLEval.DSHSeq
-                              (RHCOLEval.DSHAlloc (NatAsNT.MNatAsNT.to_nat 2)
-                                 (RHCOLEval.DSHSeq
-                                    (RHCOLEval.DSHLoop 2
-                                       (RHCOLEval.DSHAlloc
-                                          (NatAsNT.MNatAsNT.to_nat 1)
-                                          (RHCOLEval.DSHSeq
-                                             (RHCOLEval.DSHAssign
-                                                (RHCOL.PVar
-                                                   (S
-                                                   (S (S (S (S (S (S (S 1)))))))),
-                                                RHCOLEval.NPlus
-                                                  (RHCOLEval.NPlus
-                                                   (RHCOLEval.NConst
-                                                   (NatAsNT.MNatAsNT.to_nat 1))
-                                                   (RHCOLEval.NMult
-                                                   (RHCOLEval.NVar 3)
-                                                   (RHCOLEval.NConst
-                                                   (NatAsNT.MNatAsNT.to_nat 1))))
-                                                  (RHCOLEval.NMult
-                                                   (RHCOLEval.NVar 1)
-                                                   (RHCOLEval.NMult
-                                                   (RHCOLEval.NConst
-                                                   (NatAsNT.MNatAsNT.to_nat 2))
-                                                   (RHCOLEval.NConst
-                                                   (NatAsNT.MNatAsNT.to_nat 1)))))
-                                                (RHCOL.PVar 0,
-                                                RHCOLEval.NConst
-                                                  (NatAsNT.MNatAsNT.to_nat 0)))
-                                             (RHCOLEval.DSHAssign
-                                                (RHCOL.PVar 0,
-                                                RHCOLEval.NConst
-                                                  (NatAsNT.MNatAsNT.to_nat 0))
-                                                (RHCOL.PVar (S (S 0)),
-                                                RHCOLEval.NVar 1)))))
-                                    (RHCOLEval.DSHBinOp 1
-                                       (RHCOL.PVar 0)
-                                       (RHCOL.PVar (S (S 0)))
-                                       (RHCOLEval.AAbs
-                                          (RHCOLEval.AMinus
-                                             (RHCOLEval.AVar 1)
-                                             (RHCOLEval.AVar 0))))))
-                              (RHCOLEval.DSHMemMap2 1
-                                 (RHCOL.PVar (S (S 0)))
-                                 (RHCOL.PVar 1) (RHCOL.PVar (S (S 0)))
-                                 (RHCOLEval.AMax (RHCOLEval.AVar 1)
-                                    (RHCOLEval.AVar 0)))))))
-                  (RHCOLEval.DSHAssign
-                     (RHCOL.PVar 0,
-                     RHCOLEval.NConst (NatAsNT.MNatAsNT.to_nat 0))
-                     (RHCOL.PVar (S 0),
-                     RHCOLEval.NConst (NatAsNT.MNatAsNT.to_nat 1))))))
-         (RHCOLEval.DSHBinOp 1 (RHCOL.PVar 0) (RHCOL.PVar (S (S 0)))
-            (RHCOLEval.AZless (RHCOLEval.AVar 1) (RHCOLEval.AVar 0)))).
-
-  Lemma DynWin_AHCOL_to_RHCOL_compute :
-    AHCOLtoRHCOL.translate dynwin_AHCOL = inr DynWin_RHCOL.
-  Proof.
-    unfold DynWin_RHCOL.
-    cbn.
-
-    assert (Z : AHCOLtoRHCOL.translateCTypeConst CarrierAz
-            ≡ @inr string _ MRasCT.CTypeZero).
-    {
-      unfold AHCOLtoRHCOL.translateCTypeConst.
-      repeat break_if; try reflexivity; exfalso.
-      all: clear - n; contradict n; reflexivity.
-    }
-
-    assert (O : AHCOLtoRHCOL.translateCTypeConst CarrierA1
-            ≡ @inr string _ MRasCT.CTypeOne).
-    {
-      unfold AHCOLtoRHCOL.translateCTypeConst.
-      repeat break_if; try reflexivity; exfalso.
-      -
-        clear - e.
-        unfold CarrierAasCT.CTypeZero in e.
-        pose proof CarrierAasCT.CTypeZeroOneApart as C.
-        contradict C.
-        symmetry.
-        assumption.
-      -
-        clear - n0.
-        contradict n0.
-        reflexivity.
-    }
-
-    setoid_rewrite Z.
-    setoid_rewrite O.
-    setoid_rewrite Z.
-    repeat constructor. (* not a reflexive relation :) *)
-  Qed.
-
-  (** * FHCOL *)
-  Definition DynWin_FHCOL :=
-    DSHAlloc {| Int64.intval := 2; Int64.intrange := conj eq_refl eq_refl |}
-      (DSHSeq
-         (DSHSeq
-            (DSHAlloc
-               {| Int64.intval := 1; Int64.intrange := conj eq_refl eq_refl |}
-               (DSHSeq
-                  (DSHSeq (DSHMemInit (FHCOL.PVar 0) Float64asCT.Float64Zero)
-                     (DSHAlloc
-                        {|
-                          Int64.intval := 1;
-                          Int64.intrange := conj eq_refl eq_refl
-                        |}
-                        (DSHLoop 3
-                           (DSHSeq
-                              (DSHAlloc
-                                 {|
-                                   Int64.intval := 1;
-                                   Int64.intrange := conj eq_refl eq_refl
-                                 |}
-                                 (DSHSeq
-                                    (DSHAssign
-                                       (FHCOL.PVar 7,
-                                       NConst
-                                         {|
-                                           Int64.intval := 0;
-                                           Int64.intrange :=
-                                             conj eq_refl eq_refl
-                                         |})
-                                       (FHCOL.PVar 0,
-                                       NConst
-                                         {|
-                                           Int64.intval := 0;
-                                           Int64.intrange :=
-                                             conj eq_refl eq_refl
-                                         |}))
-                                    (DSHAlloc
-                                       {|
-                                         Int64.intval := 1;
-                                         Int64.intrange := conj eq_refl eq_refl
-                                       |}
-                                       (DSHSeq
-                                          (DSHPower
-                                             (NVar 2)
-                                             (FHCOL.PVar 1,
-                                             NConst
-                                               {|
-                                                 Int64.intval := 0;
-                                                 Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                               |})
-                                             (FHCOL.PVar 0,
-                                             NConst
-                                               {|
-                                                 Int64.intval := 0;
-                                                 Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                               |}) (AMult (AVar 1) (AVar 0))
-                                             Float64asCT.Float64One)
-                                          (DSHIMap 1
-                                             (FHCOL.PVar 0)
-                                             (FHCOL.PVar 3)
-                                             (AMult
-                                                (AVar 0)
-                                                (ANth
-                                                   (MPtrDeref (FHCOL.PVar 8))
-                                                   (NVar 4))))))))
-                              (DSHMemMap2 1 (FHCOL.PVar 2)
-                                 (FHCOL.PVar 1) (FHCOL.PVar 2)
-                                 (APlus (AVar 1) (AVar 0)))))))
-                  (DSHAssign
-                     (FHCOL.PVar 0,
-                     NConst
-                       {|
-                         Int64.intval := 0;
-                         Int64.intrange := conj eq_refl eq_refl
-                       |})
-                     (FHCOL.PVar 1,
-                     NConst
-                       {|
-                         Int64.intval := 0;
-                         Int64.intrange := conj eq_refl eq_refl
-                       |}))))
-            (DSHAlloc
-               {| Int64.intval := 1; Int64.intrange := conj eq_refl eq_refl |}
-               (DSHSeq
-                  (DSHSeq (DSHMemInit (FHCOL.PVar 0) Float64asCT.Float64Zero)
-                     (DSHAlloc
-                        {|
-                          Int64.intval := 1;
-                          Int64.intrange := conj eq_refl eq_refl
-                        |}
-                        (DSHLoop 2
-                           (DSHSeq
-                              (DSHAlloc
-                                 {|
-                                   Int64.intval := 2;
-                                   Int64.intrange := conj eq_refl eq_refl
-                                 |}
-                                 (DSHSeq
-                                    (DSHLoop 2
-                                       (DSHAlloc
-                                          {|
-                                            Int64.intval := 1;
-                                            Int64.intrange :=
-                                              conj eq_refl eq_refl
-                                          |}
-                                          (DSHSeq
-                                             (DSHAssign
-                                                (FHCOL.PVar 9,
-                                                NPlus
-                                                  (NPlus
-                                                   (NConst
-                                                   {|
-                                                   Int64.intval := 1;
-                                                   Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                                   |})
-                                                   (NMult
-                                                   (NVar 3)
-                                                   (NConst
-                                                   {|
-                                                   Int64.intval := 1;
-                                                   Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                                   |})))
-                                                  (NMult
-                                                   (NVar 1)
-                                                   (NMult
-                                                   (NConst
-                                                   {|
-                                                   Int64.intval := 2;
-                                                   Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                                   |})
-                                                   (NConst
-                                                   {|
-                                                   Int64.intval := 1;
-                                                   Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                                   |}))))
-                                                (FHCOL.PVar 0,
-                                                NConst
-                                                  {|
-                                                   Int64.intval := 0;
-                                                   Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                                  |}))
-                                             (DSHAssign
-                                                (FHCOL.PVar 0,
-                                                NConst
-                                                  {|
-                                                   Int64.intval := 0;
-                                                   Int64.intrange :=
-                                                   conj eq_refl eq_refl
-                                                  |})
-                                                (FHCOL.PVar 2, NVar 1)))))
-                                    (DSHBinOp 1 (FHCOL.PVar 0)
-                                       (FHCOL.PVar 2)
-                                       (AAbs (AMinus (AVar 1) (AVar 0))))))
-                              (DSHMemMap2 1 (FHCOL.PVar 2)
-                                 (FHCOL.PVar 1) (FHCOL.PVar 2)
-                                 (AMax (AVar 1) (AVar 0)))))))
-                  (DSHAssign
-                     (FHCOL.PVar 0,
-                     NConst
-                       {|
-                         Int64.intval := 0;
-                         Int64.intrange := conj eq_refl eq_refl
-                       |})
-                     (FHCOL.PVar 1,
-                     NConst
-                       {|
-                         Int64.intval := 1;
-                         Int64.intrange := conj eq_refl eq_refl
-                       |})))))
-         (DSHBinOp 1 (FHCOL.PVar 0) (FHCOL.PVar 2) (AZless (AVar 1) (AVar 0)))).
-
-  Lemma DynWin_RHCOL_to_FHCOL_compute :
-    RHCOLtoFHCOL.translate DynWin_RHCOL = inr DynWin_FHCOL.
-  Proof.
-    unfold DynWin_RHCOL.
-    cbn.
-
-    assert (Z : RHCOLtoFHCOL.translateCTypeConst MRasCT.CTypeZero
-            ≡ @inr string _ Float64asCT.Float64Zero).
-    {
-      unfold RHCOLtoFHCOL.translateCTypeConst.
-      repeat break_if; try reflexivity; exfalso.
-      all: clear - n; contradict n; reflexivity.
-    }
-
-    assert (O : RHCOLtoFHCOL.translateCTypeConst MRasCT.CTypeOne
-            ≡ @inr string _ Float64asCT.Float64One).
-    {
-      unfold RHCOLtoFHCOL.translateCTypeConst.
-      repeat break_if; try reflexivity; exfalso.
-      -
-        clear - e.
-        cbv in e.
-        pose proof MRasCT.CTypeZeroOneApart.
-        congruence.
-      -
-        clear - n0.
-        contradict n0.
-        reflexivity.
-    }
-
-    setoid_rewrite Z.
-    setoid_rewrite O.
-    setoid_rewrite Z.
-    f_equiv.
-    repeat constructor. (* not a reflexive relation :) *)
-  Qed.
-
-  Definition dynwin_R_σ' :=
-    match AHCOLtoRHCOL.translateEvalContext build_dynwin_σ with
-    | inr σ => σ
-    | _ => []
-    end.
-
-  Definition rhcol_nexpr_closure_trace :=
-    match RHCOLEval.intervalEvalDSHOperator
-            (RHCOLEval.evalNatContext_of_evalContext dynwin_R_σ')
-            DynWin_RHCOL
-            []
-            (RHCOLEval.estimateFuel DynWin_RHCOL) with
-    | Some (inr t) => t
-    | _ => []
-    end.
-
-  Definition dynwin_F_σ' :=
-    match RHCOLtoFHCOL.translateEvalContext dynwin_R_σ' with
-    | inr σ => σ
-    | _ => []
-    end.
-
-  Definition fhcol_nexpr_closure_trace :=
-    match FHCOLEval.intervalEvalDSHOperator
-            (FHCOLEval.evalNatContext_of_evalContext dynwin_F_σ')
-            DynWin_FHCOL
-            []
-            (FHCOLEval.estimateFuel DynWin_FHCOL) with
-    | Some (inr t) => t
-    | _ => []
-    end.
 
   Ltac crush_int :=
     repeat rewrite !Int64.unsigned_repr;
@@ -2222,7 +1827,6 @@ Section TopLevel.
            Int64.lt
       in *.
 
-
   (* note: the two [try] blocks are for RHCOL/FHCOL lemma *)
   Ltac destruct_context_range_lookup ΣR x :=
     let TΣR := fresh "TΣR" in
@@ -2240,12 +1844,176 @@ Section TopLevel.
     destruct TΣR as (nv & p & NV & Σ);
     rewrite Σ.
 
-  Lemma rhcol_fhcol_nexpr_closure_trace_equiv :
-    evalNExpr_closure_trace_equiv
-      rhcol_nexpr_closure_trace
-      fhcol_nexpr_closure_trace.
+  (* TODO: move *)
+  Lemma trivial2_Proper `{AE : Equiv A} `{BE : Equiv B} :
+    Proper (equiv ==> equiv ==> iff) (@trivial2 A B).
   Proof.
-    cbn.
+    repeat constructor.
+  Qed.
+
+  
+
+  (* Instances for trivial comparison of CType values
+     in RHCOL->FHCOL translation.
+
+     These allow to infer structural properties of translation,
+     while disregarding CType values (and CType values only).
+
+     The statement [RF_Structural_Semantic_Preservation]
+     is the full semantic preservation on RHCOL->FHCOL, up to CType values.
+   *)
+  Local Definition trivial_RF_CHE : RHCOLtoFHCOL.CTranslation_heq :=
+    {|
+      heq_CType := trivial2;
+      heq_CType_proper := trivial2_Proper;
+    |}.
+
+  Local Fact trivial_RF_COP
+    : @RHCOLtoFHCOL.COpTranslationProps trivial_RF_CHE.
+  Proof.
+    repeat constructor.
+  Qed.
+
+  Local Fact trivial_RF_translateCTypeValue_heq_CType :
+    ∀ (x : R) (x' : Bits.binary64),
+      translateCTypeValue x = inr x' →
+      @heq_CType trivial_RF_CHE x x'.
+  Proof.
+    repeat constructor.
+  Qed.
+
+  Local Definition trivial_RF_CTO : @RHCOLtoFHCOL.CTranslationOp trivial_RF_CHE :=
+    {|
+      translateCTypeValue := @translateCTypeValue _ RF_CTO;
+      translateCTypeValue_heq_CType := trivial_RF_translateCTypeValue_heq_CType;
+      translateCTypeConst_translateCTypeValue_compat :=
+        @translateCTypeConst_translateCTypeValue_compat _ RF_CTO;
+    |}.
+
+  Definition RF_Structural_Semantic_Preservation :=
+    @RHCOLtoFHCOL.translation_semantics_correct
+      RF_NHE
+      trivial_RF_CHE
+      RF_NTP
+      trivial_RF_COP.
+  
+  Lemma RHCOLtoFHCOL_NExpr_closure_trace_equiv
+        (dynwin_R_σ : RHCOLEval.evalContext)
+        (dynwin_F_σ : evalContext)
+        (dynwin_rhcol : RHCOL.DSHOperator)
+        (dynwin_fhcol : FHCOL.DSHOperator)
+    :
+    AHCOLtoRHCOL.translate dynwin_AHCOL = inr dynwin_rhcol ->
+    RHCOLtoFHCOL.translate dynwin_rhcol = inr dynwin_fhcol ->
+
+    AHCOLtoRHCOL.translateEvalContext build_dynwin_σ = inr dynwin_R_σ ->
+    RHCOLtoFHCOL.translateEvalContext dynwin_R_σ = inr dynwin_F_σ ->
+
+    hopt (herr (@evalNExpr_closure_trace_equiv RF_NHE trivial_RF_CHE))
+         (RHCOLEval.intervalEvalDSHOperator_σ
+            dynwin_R_σ dynwin_rhcol []
+            (RHCOLEval.estimateFuel dynwin_rhcol))
+         (intervalEvalDSHOperator_σ
+            dynwin_F_σ dynwin_fhcol []
+            (estimateFuel dynwin_fhcol)).
+  Proof.
+    intros AR RF ARΣ RFΣ.
+
+    assert (AR0 : AHCOLtoRHCOL.translateCTypeConst CarrierAz
+            ≡ @inr string _ MRasCT.CTypeZero).
+    {
+      unfold AHCOLtoRHCOL.translateCTypeConst.
+      repeat break_if; try reflexivity; exfalso.
+      all: clear - n; contradict n; reflexivity.
+    }
+
+    assert (AR1 : AHCOLtoRHCOL.translateCTypeConst CarrierA1
+            ≡ @inr string _ MRasCT.CTypeOne).
+    {
+      unfold AHCOLtoRHCOL.translateCTypeConst.
+      repeat break_if; try reflexivity; exfalso.
+      -
+        clear - e.
+        unfold CarrierAasCT.CTypeZero in e.
+        pose proof CarrierAasCT.CTypeZeroOneApart as C.
+        contradict C.
+        symmetry.
+        assumption.
+      -
+        clear - n0.
+        contradict n0.
+        reflexivity.
+    }
+
+    cbn in AR.
+    repeat progress (try setoid_rewrite AR0 in AR;
+                     try setoid_rewrite AR1 in AR).
+    invc AR; rename H1 into AR.
+    cbn in ARΣ.
+            
+
+    assert (RF0 : RHCOLtoFHCOL.translateCTypeConst MRasCT.CTypeZero
+            ≡ @inr string _ Float64asCT.Float64Zero).
+    {
+      unfold RHCOLtoFHCOL.translateCTypeConst.
+      repeat break_if; try reflexivity; exfalso.
+      all: clear - n; contradict n; reflexivity.
+    }
+
+    assert (RF1 : RHCOLtoFHCOL.translateCTypeConst MRasCT.CTypeOne
+            ≡ @inr string _ Float64asCT.Float64One).
+    {
+      unfold RHCOLtoFHCOL.translateCTypeConst.
+      repeat break_if; try reflexivity; exfalso.
+      -
+        clear - e.
+        cbv in e.
+        pose proof MRasCT.CTypeZeroOneApart.
+        congruence.
+      -
+        clear - n0.
+        contradict n0.
+        reflexivity.
+    }
+
+    pose proof AR as AR'.
+    apply RHCOLtoFHCOL.translate_proper in AR'.
+    rewrite <-AR' in RF.
+    clear AR'.
+    
+    cbn in RF.
+    repeat progress (try setoid_rewrite RF0 in RF;
+                     try setoid_rewrite RF1 in RF).
+    inl_inr_inv.
+
+    
+    remember (RHCOLEval.DSHAlloc _ _) as dynwin_rhcol_comp eqn:RC.
+    remember (FHCOLEval.DSHAlloc _ _) as dynwin_fhcol_comp eqn:FC.
+    (* poor man's [rewrite <-RC, <-FC] *)
+    assert (T1 : RHCOLEval.intervalEvalDSHOperator_σ
+              dynwin_R_σ dynwin_rhcol []
+              (RHCOLEval.estimateFuel dynwin_rhcol)
+            =
+              RHCOLEval.intervalEvalDSHOperator_σ
+                dynwin_R_σ dynwin_rhcol_comp []
+                (RHCOLEval.estimateFuel dynwin_rhcol_comp))
+      by now rewrite AR.
+    assert (T2 : FHCOLEval.intervalEvalDSHOperator_σ
+                   dynwin_F_σ dynwin_fhcol []
+                   (FHCOLEval.estimateFuel dynwin_fhcol)
+                 =
+                   FHCOLEval.intervalEvalDSHOperator_σ
+                     dynwin_F_σ dynwin_fhcol_comp []
+                     (FHCOLEval.estimateFuel dynwin_fhcol_comp))
+      by now rewrite RF.
+    eapply hopt_proper;
+      [ apply herr_proper, evalNExpr_closure_trace_equiv_proper
+      | apply T1
+      | apply T2
+      | ].
+
+    (** Following is the semi-manual "numerical analysis" part **)
+    subst; cbn.
     repeat constructor.
 
     1,3,5,7,9-14: cbn.
@@ -2263,7 +2031,7 @@ Section TopLevel.
     1-10: constructor.
     1-10: rewrite Σ, Σ0 in Σ3E.
     1-10: cbn in Σ3E; invc Σ3E; invc H1; invc H0; assumption.
-
+    
     (* TODO: all 4 subogals are exact copies *)
     -
       cbn.
@@ -2403,59 +2171,6 @@ Section TopLevel.
       crush_int.
   Qed.
 
-  (* TODO: move *)
-  Lemma trivial2_Proper `{AE : Equiv A} `{BE : Equiv B} :
-    Proper (equiv ==> equiv ==> iff) (@trivial2 A B).
-  Proof.
-    repeat constructor.
-  Qed.
-
-  
-
-  (* Instances for trivial comparison of CType values
-     in RHCOL->FHCOL translation.
-
-     These allow to infer structural properties of translation,
-     while disregarding CType values (and CType values only).
-
-     The statement [RF_Structural_Semantic_Preservation]
-     is the full semantic preservation on RHCOL->FHCOL, up to CType values.
-   *)
-  Local Definition trivial_RF_CHE : RHCOLtoFHCOL.CTranslation_heq :=
-    {|
-      heq_CType := trivial2;
-      heq_CType_proper := trivial2_Proper;
-    |}.
-
-  Local Fact trivial_RF_COP
-    : @RHCOLtoFHCOL.COpTranslationProps trivial_RF_CHE.
-  Proof.
-    repeat constructor.
-  Qed.
-
-  Local Fact trivial_RF_translateCTypeValue_heq_CType :
-    ∀ (x : R) (x' : Bits.binary64),
-      translateCTypeValue x = inr x' →
-      @heq_CType trivial_RF_CHE x x'.
-  Proof.
-    repeat constructor.
-  Qed.
-
-  Local Definition trivial_RF_CTO : @RHCOLtoFHCOL.CTranslationOp trivial_RF_CHE :=
-    {|
-      translateCTypeValue := @translateCTypeValue _ RF_CTO;
-      translateCTypeValue_heq_CType := trivial_RF_translateCTypeValue_heq_CType;
-      translateCTypeConst_translateCTypeValue_compat :=
-        @translateCTypeConst_translateCTypeValue_compat _ RF_CTO;
-    |}.
-
-  Definition RF_Structural_Semantic_Preservation :=
-    @RHCOLtoFHCOL.translation_semantics_correct
-      RF_NHE
-      trivial_RF_CHE
-      RF_NTP
-      trivial_RF_COP.
-
   (*
     Translation validation proof of semantic preservation
     of successful translation of [dynwin_orig] into FHCOL program.
@@ -2472,7 +2187,7 @@ Section TopLevel.
     forall x y,
       (* evaluatoion of original operator *)
       dynwin_orig a x = y ->
-
+      
       forall dynwin_R_memory dynwin_F_memory dynwin_R_σ dynwin_F_σ dynwin_rhcol dynwin_fhcol,
         (* Compile AHCOL -> RHCOL -> FHCOL *)
         AHCOLtoRHCOL.translate dynwin_AHCOL = inr dynwin_rhcol ->
@@ -2510,7 +2225,7 @@ Section TopLevel.
               /\ FHCOLEval.memory_lookup f_omemory dynwin_y_addr = Some y_fmem
               /\ OutRel a_rmem x_rmem y_rmem y_fmem.
   Proof.
-    intros * HC * CA CR [CAM CRM] [CAE CRE] * [RA [RX C]].
+    intros * HC * CA CR CAM CRM CAE CRE * RA RX C.
 
     remember (AHCOLEval.memory_set
                 (build_dynwin_memory a x)
@@ -2591,8 +2306,6 @@ Section TopLevel.
           apply SH1Y.
 
           {
-            clear - SX SY.
-
             pose proof (@out_as_range _ _ _ _ _ _ (DynWinSigmaHCOL1_Facts a)) as D.
             specialize (D sx).
 
@@ -2738,116 +2451,98 @@ Section TopLevel.
 
     (* moved from [dynwin_MSHCOL1] to [dynwin_rhcol] *)
 
-    assert(RM : exists r_omemory, AHCOLtoRHCOL.translate_runtime_memory a_omemory = inr r_omemory).
+    pose proof AHCOLtoRHCOL.translation_semantics_correct_strict
+         dynwin_AHCOL
+         dynwin_rhcol
+         (AHCOLEval.estimateFuel dynwin_AHCOL)
+         (RHCOLEval.estimateFuel dynwin_rhcol)
+         dynwin_σ
+         dynwin_R_σ
+         (build_dynwin_memory a x)
+         dynwin_R_memory
+      as HEQAR.
+    full_autospecialize HEQAR;
+      [ now apply AHCOLtoRHCOL.translation_syntax_always_correct
+      | now apply AHCOLtoRHCOL.translateEvalContext_same_indices
+      | now apply AHCOLtoRHCOL.translate_runtime_memory_same_indices
+      | ].
+    destruct (AHCOLEval.evalDSHOperator dynwin_σ dynwin_AHCOL
+                                        (build_dynwin_memory a x)
+                                        (AHCOLEval.estimateFuel dynwin_AHCOL))
+             eqn:EA;
+      destruct (RHCOLEval.evalDSHOperator dynwin_R_σ dynwin_rhcol
+                                          dynwin_R_memory
+                                          (RHCOLEval.estimateFuel dynwin_rhcol))
+               eqn:ER;
+      invc HEQAR;
+      try some_none.
+
+    invc H1; invc AE; [invc H1 | invc H2].
+    rename a0 into a_omemory, b into r_omemory, H into RM, H3 into AM.
+
+    exists r_omemory.
+
+    apply AHCOLtoRHCOL.heq_memory_translate_runtime_memory in RM.
+    (* poor man's [rewrite AM in RM] *)
+    erewrite AHCOLtoRHCOL.translate_runtime_memory_proper
+      in RM by eapply AM.
+    apply AHCOLtoRHCOL.NM_err_sequence_inr_fun_spec in RM.
+    specialize (RM dynwin_y_addr).
+    rewrite !Memory.NP.F.map_o in RM.
+    unfold option_map in RM.
+    unfold AHCOLEval.memory_set in RM.
+    rewrite Memory.NP.F.add_eq_o in RM by reflexivity.
+    break_match; invc RM.
+    rename m into y_rmem, Heqo into YRM, H1 into YRME.
+
+    exists y_rmem.
+    split; [reflexivity |].
+    split; [rewrite <-YRM; reflexivity |].
+    split; [now symmetry |].
+
+    pose proof
+         RF_Structural_Semantic_Preservation
+         dynwin_rhcol
+         dynwin_fhcol
+         (RHCOLEval.estimateFuel dynwin_rhcol)
+         (FHCOLEval.estimateFuel dynwin_fhcol)
+         dynwin_R_σ
+         dynwin_F_σ
+         dynwin_R_memory
+         dynwin_F_memory
+      as HEQRF.
+    full_autospecialize HEQRF.
     {
-      unfold AHCOLtoRHCOL.translate_runtime_memory.
-      unfold AHCOLtoRHCOL.translate_runtime_mem_block.
-
-      apply NM_err_sequence_OK.
-      clear - AHCOLtoRHCOL_total.
-      unfold Memory.NP.for_all_range.
-      apply Memory.NP.for_all_iff;
-        [now repeat break_match |].
-      intros * M.
-      apply Memory.NP.F.map_mapsto_iff in M.
-      destruct M as (v & [M KV]).
-      subst; clear - AHCOLtoRHCOL_total.
-
-      enough (OK : exists vm,
-                 (AHCOLtoRHCOL.NM_err_sequence
-                    (Memory.NM.map AHCOLtoRHCOL.translateCTypeValue v)) = inr vm).
-      {
-        destruct OK as [vm OK].
-        unfold is_OK_bool.
-        break_match; inv OK; reflexivity.
-      }
-
-      apply NM_err_sequence_OK.
-      unfold Memory.NP.for_all_range.
-      apply Memory.NP.for_all_iff;
-        [now repeat break_match |].
-      intros * M.
-      apply Memory.NP.F.map_mapsto_iff in M.
-      destruct M as (v' & [M KV]).
-      subst; clear - AHCOLtoRHCOL_total.
-      specialize (AHCOLtoRHCOL_total v').
-      destruct AHCOLtoRHCOL_total as [r T].
-      now rewrite T.
+      now eapply translation_syntax_always_correct.
+      Unshelve. apply trivial_RF_CTO.
     }
-    destruct RM as [r_omemory RM].
-    exists (r_omemory).
-
-    intros ER y_rmem RY.
-
-    split.
-    1: {
-      (* Proof of correctness up to R *)
-      subst.
-      unfold AHCOLtoRHCOL.translate_memory in RM.
-      apply AHCOLtoRHCOL.NM_err_sequence_inr_fun_spec in RM.
-      specialize (RM dynwin_y_addr).
-      rewrite !Memory.NP.F.map_o in RM.
-      unfold AHCOLEval.memory_set in RM.
-      rewrite Memory.NP.F.add_eq_o in RM by reflexivity.
-      rewrite RY in RM.
-      cbv [option_map] in *.
-      some_inv.
-      now symmetry.
-    }
-
-    assert (T : exists (f_omemory : memory),
-              evalDSHOperator dynwin_F_σ dynwin_fhcol dynwin_F_memory
-                              (estimateFuel dynwin_fhcol) = Some (inr f_omemory)).
     {
-      (* this requires some NType-related numerical analysis
-         to ensure no runtime error occurs after translation *)
-      pose proof
-           RF_Structural_Semantic_Preservation
-           dynwin_rhcol
-           dynwin_fhcol
-           (RHCOLEval.estimateFuel dynwin_rhcol)
-           (FHCOLEval.estimateFuel dynwin_fhcol)
-           dynwin_R_σ
-           dynwin_F_σ
-           dynwin_R_memory
-           dynwin_F_memory
-        as HEQRF.
-      destruct HEQRF;
-        try some_none.
-      -
-        eapply translation_syntax_always_correct.
-        assumption.
-        Unshelve.
-        apply trivial_RF_CTO.
-      -
-        eapply translateEvalContext_same_indices.
-        instantiate (1:=trivial_RF_CTO).
-        assumption.
-      -
-        eapply translate_runtime_memory_same_indices.
-        instantiate (1:=trivial_RF_CTO).
-        assumption.
-      -
-        admit.
-      -
-        invc H; [invc ER; invc H1 |].
-        eexists; reflexivity.
+      eapply @translateEvalContext_same_indices with (CTO:=trivial_RF_CTO).
+      assumption. 
     }
-    destruct T as (f_omemory & EF).
-
-    assert (FY : mem_block_exists dynwin_y_addr f_omemory).
     {
-      (* assumed, as proving [OutRel] later will most likely
-         require a form of this proven separately *)
-      admit.
+      eapply @translate_runtime_memory_same_indices with (CTO:=trivial_RF_CTO).
+      assumption.
+    }
+    {
+      now apply @RHCOLtoFHCOL_NExpr_closure_trace_equiv.
     }
 
-    apply mem_block_exists_exists in FY.
-    destruct FY as (y_fmem & FY).
-    exists f_omemory; exists y_fmem.
-    repeat split.
-    assumption.
-    now rewrite FY.
+    destruct HEQRF; try some_none.
+    invc H; invc ER.
+    rename b0 into f_omemory, H0 into FM.
+
+    exists f_omemory.
+
+    pose proof FM as YFM.
+    specialize (YFM dynwin_y_addr).
+    unfold RHCOLEval.memory_lookup in YFM.
+    rewrite YRM in YFM.
+    invc YFM.
+    rename b into y_fmem, H1 into YFM, H0 into YFMM.
+
+    exists y_fmem.
+    do 2 (split; [reflexivity |]).
 
     (* OutRel must hold (a,x,y_R,y_F) *)
     admit. (* this is provided by user *)

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -343,7 +343,7 @@ Section SigmaHCOL_rewriting.
    Instance DynWinSigmaHCOL1_Facts
            (a: avector 3):
     SHOperator_Facts _ (dynwin_SHCOL1 a).
-  Proof. (*
+  Proof.
     unfold dynwin_SHCOL1.
     solve_facts.
     (* Now let's take care of remaining proof obligations *)
@@ -388,7 +388,7 @@ Section SigmaHCOL_rewriting.
       reflexivity.
 
       crush.
-  Qed. *) Admitted.
+  Qed.
 
   Lemma op_Vforall_P_SHPointwise
         {m n: nat}
@@ -428,7 +428,7 @@ Section SigmaHCOL_rewriting.
   Lemma DynWinSigmaHCOL1_Value_Correctness
         (a: avector 3)
     : dynwin_SHCOL a = dynwin_SHCOL1 a.
-  Proof. (*
+  Proof.
     unfold dynwin_SHCOL.
     unfold SumSparseEmbedding.
 
@@ -651,7 +651,7 @@ Section SigmaHCOL_rewriting.
            end.
     replace p with p1 by apply proof_irrelevance.
     reflexivity.
-  Qed. *) Admitted.
+  Qed.
 
 
   (* Couple additional structual properties: input and output of the
@@ -840,7 +840,7 @@ Section SHCOL_to_MSHCOL.
 
   Theorem dynwin_SHCOL_MSHCOL_compat (a: avector 3):
     SH_MSH_Operator_compat (dynwin_SHCOL1 a) (dynwin_MSHCOL1 a).
-  Proof. (*
+  Proof.
     unfold dynwin_SHCOL1, dynwin_MSHCOL1.
     unfold ISumUnion.
 
@@ -891,7 +891,7 @@ Section SHCOL_to_MSHCOL.
       apply Set_Obligation_1.
     -
       apply Set_Obligation_1.
-  Qed. *) Admitted.
+  Qed.
 
 End SHCOL_to_MSHCOL.
 
@@ -1024,7 +1024,7 @@ Section MSHCOL_to_AHCOL.
                         dynwin_memory
                         DSH_x_p DSH_y_p
                         DynWin_pure.
-    Proof. (*
+    Proof.
       unfold dynwin_AHCOL, DSH_y_p, DSH_x_p.
       unfold dynwin_x_addr, dynwin_y_addr, dynwin_a_addr, nglobals in *.
       unfold dynwin_MSHCOL1.
@@ -1428,7 +1428,7 @@ Section MSHCOL_to_AHCOL.
         -
           solve_facts.
       }
-    Qed. *) Admitted.
+    Qed.
 
   End DummyEnv.
 
@@ -2546,7 +2546,7 @@ Section TopLevel.
 
     (* OutRel must hold (a,x,y_R,y_F) *)
     admit. (* this is provided by user *)
-     *)
+
   Admitted.
 
 

--- a/coq/Util/ErrorSetoid.v
+++ b/coq/Util/ErrorSetoid.v
@@ -288,6 +288,23 @@ Section herr.
   | herr_f_inl_r : forall e x, herr_f x (inl e)
   | herr_f_inr : forall a b, R a b -> herr_f (inr a) (inr b).
 
+  Instance herr_proper
+           `{EQa : Equiv A}
+           `{EQb : Equiv B}
+           {PR : Proper ((=) ==> (=) ==> (iff)) R} :
+    Proper ((=) ==> (=) ==> (iff)) herr.
+  Proof.
+    intros a1 a2 AE b1 b2 BE.
+    destruct a1, a2, b1, b2;
+      invc AE; invc BE.
+    1-3: split; intro C; invc C.
+    split.
+    all: intro E; invc E; constructor.
+    specialize (PR a a0 H1 b b0 H2).
+    tauto.
+    eapply PR; eassumption.
+  Qed.
+
 End herr.
 Arguments herr {A B} R.
 Arguments herr_c {A B} R.

--- a/coq/Util/OptionSetoid.v
+++ b/coq/Util/OptionSetoid.v
@@ -472,6 +472,23 @@ Section hopt.
   | hopt_i_None_Some : forall a, hopt_i None (Some a)
   | hopt_i_Some : forall a b, R a b -> hopt_i (Some a) (Some b).
 
+  Instance hopt_proper
+           `{EQa : Equiv A}
+           `{EQb : Equiv B}
+           {PR : Proper ((=) ==> (=) ==> (iff)) R} :
+    Proper ((=) ==> (=) ==> (iff)) hopt.
+  Proof.
+    intros a1 a2 AE b1 b2 BE.
+    destruct a1, a2, b1, b2;
+      invc AE; invc BE.
+    2-4: split; intro C; invc C.
+    split.
+    all: intro E; invc E; constructor.
+    specialize (PR a a0 H1 b b0 H2).
+    tauto.
+    eapply PR; eassumption.
+  Qed.
+
 End hopt.
 Arguments hopt {A B} R.
 Arguments hopt_r {A B} R.


### PR DESCRIPTION
#### Summary of changes:
* Rework classes of assumptions about translation functions (21414e1)
Allowing finer-grained control over assumptions which might not hold for certain steps of the translation.
* Remove the now-unnecessary hacks which were previously used to provide that level of control (1b2621f)
(+ strengthen lemmas accordingly)
* Prove relaxed semantic preservation on less-strict translation steps (f6f0e8e)
* Prove strict semantic preservation on strict translation steps (f23cd8b)
* Strengthen the DynWin end-to-end theorem (b2763e9)
  + Fix connection between RHCOL->FHCOL
  + Prove strict semantic preservation up to RHCOL (as far as theoretically possible)
* Inline RCHOL->FHCOL numerical proofs (previously done by hand/hard-coded) (110bce7)