### PR TITLE
Stronger assumptions about NType constants

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
     def BUILD_IF_BRANCH = ['master','develop']
  */
 
-def BUILD_IF_BRANCH = ['master','dshtranslator_class_rework']
+def BUILD_IF_BRANCH = ['master','NType_constants']
 
 pipeline {
     agent { 

--- a/coq/ASigmaHCOL/NatAsNT.v
+++ b/coq/ASigmaHCOL/NatAsNT.v
@@ -17,6 +17,7 @@ Module MNatAsNT <: NType.
   Instance NTypeEqDec: forall x y: t, Decision (x = y) := nat_dec.
 
   Definition NTypeZero := O.
+  Definition NTypeOne := 1.
 
   (* could always be converted to `nat` *)
   Definition to_nat (n:t) : nat := n.
@@ -72,12 +73,6 @@ Module MNatAsNT <: NType.
     reflexivity.
   Qed.
 
-  Lemma from_nat_zero: exists z, from_nat O ≡ inr z.
-  Proof.
-    eexists.
-    auto.
-  Qed.
-
   Lemma to_nat_from_nat :
     forall n nt,
       from_nat n = inr nt <-> to_nat nt = n.
@@ -86,6 +81,16 @@ Module MNatAsNT <: NType.
     split; intros E.
     now inl_inr_inv.
     now f_equiv.
+  Qed.
+
+  Lemma to_nat_zero : to_nat NTypeZero ≡ 0.
+  Proof.
+    reflexivity.
+  Qed.
+
+  Lemma to_nat_one : to_nat NTypeOne ≡ 1.
+  Proof.
+    reflexivity.
   Qed.
 
 End MNatAsNT.

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -4072,6 +4072,17 @@ Module MDHCOLTypeTranslator
             `{NOP : @NOpTranslationProps NHE}
             `{COP : @COpTranslationProps CHE}.
 
+    Fact heq_NTypeZero :
+      heq_NType NT.NTypeZero NT'.NTypeZero.
+    Proof.
+      apply heq_NType_translateNTypeConst_compat.
+      unfold translateNTypeConst.
+      rewrite NT.to_nat_zero.
+      apply NT'.to_nat_from_nat.
+      rewrite NT'.to_nat_zero.
+      reflexivity.
+    Qed.
+
     Lemma heq_NExpr_heq_evalNExpr
           (n : L.NExpr)
           (n' : L'.NExpr)
@@ -4108,7 +4119,8 @@ Module MDHCOLTypeTranslator
       all: exfalso.
       all: clear Heqd Heqd0; contradict n.
       all: eapply heq_NType_NTypeEquiv_compat; try eassumption.
-    Admitted.
+      all: apply heq_NTypeZero.
+    Qed.
 
     Lemma evalNExpr_closure_equiv_tauto
           (c : LE.evalNatClosure)

--- a/coq/DSigmaHCOL/DSigmaHCOLEval.v
+++ b/coq/DSigmaHCOL/DSigmaHCOLEval.v
@@ -2570,7 +2570,16 @@ Module Type MDSigmaHCOLEval
     revert σ mem mem' fuel op H.
     induction N; intros.
     -
-      apply from_nat_zero.
+      (* [eq] vs [equiv] *)
+      enough (T : ∃ nn, from_nat 0 = inr nn).
+      {
+        destruct T as [z T].
+        destruct (from_nat 0); invc T.
+        eexists; reflexivity.
+      }
+      exists NTypeZero.
+      apply to_nat_from_nat.
+      apply to_nat_zero.
     -
       cbn in *. 
       repeat break_match; try some_none; try some_inv; subst.

--- a/coq/DSigmaHCOL/NType.v
+++ b/coq/DSigmaHCOL/NType.v
@@ -14,6 +14,7 @@ Module Type NType.
 
   (* Values *)
   Parameter NTypeZero: t.
+  Parameter NTypeOne: t.
 
   (* Decidable equiality *)
   Declare Instance NTypeEqDec: forall x y: t, Decision (x = y).

--- a/coq/DSigmaHCOL/NType.v
+++ b/coq/DSigmaHCOL/NType.v
@@ -61,7 +61,8 @@ Module Type NType.
       (y<x)%nat ->
       exists yi, from_nat y ≡ inr yi.
 
-  (* 0 is always convertible *)
-  Parameter from_nat_zero: exists z, from_nat O ≡ inr z.
+  (* 0 and 1 are always converted accordingly *)
+  Parameter to_nat_zero: to_nat NTypeZero ≡ 0.
+  Parameter to_nat_one: to_nat NTypeOne ≡ 1.
 
 End NType.

--- a/coq/FSigmaHCOL/Int64asNT.v
+++ b/coq/FSigmaHCOL/Int64asNT.v
@@ -98,6 +98,7 @@ Module MInt64asNT <: NType.
   Qed.
 
   Definition NTypeZero := Int64.zero.
+  Definition NTypeOne := Int64.one.
 
   Definition from_Z (z:BinInt.Z): err t :=
     match ZArith_dec.Z_lt_dec (BinNums.Zneg BinNums.xH) z with
@@ -327,18 +328,14 @@ Module MInt64asNT <: NType.
     eauto.
   Qed.
 
-  Lemma from_nat_zero: exists z, from_nat O ≡ inr z.
+  Lemma to_nat_zero: to_nat NTypeZero ≡ 0.
   Proof.
-    exists (Int64.mkint (Int64.Z_mod_modulus BinNums.Z0) (Int64.Z_mod_modulus_range' BinNums.Z0)).
-    cbn.
-    pose proof (Int64.unsigned_range Int64.zero) as [H0 H1].
-    break_match.
-    - f_equiv.
-      f_equiv.
-      apply proof_irrelevance.
-    - contradict n.
-      lia.
+    reflexivity.
   Qed.
 
+  Lemma to_nat_one: to_nat NTypeOne ≡ 1.
+  Proof.
+    reflexivity.
+  Qed.
 
 End MInt64asNT.


### PR DESCRIPTION
By "constants", I mean built-in basis values: `NTypeZero` and `NTypeOne`.

#### Goal:
Ultimately this was used to prove the equivalence of two `NTypeZero`s before and after a translation step (60a788310901391ae2807c0fb13b857bdfe625b9). Other ways to establish that might exist, but this seems to be the smallest sufficient change.

#### Summary of changes:
* Add `NTypeOne` (2f2a977de3c53f5949592ce6da2509112903b15e)
Not actually used anywhere yet, but added as discussed.
* Strengthen [nat <-> constant] conversion properties (5def0699057c293625990b12e19a4d141ee46129)
Reasoning behind the change:
  + The previous version only established the existence of _some_ zero, regardless of the built-in constant `NTypeZero`
  + The new form (`to_nat` instead of `from_nat`) is strictly equivalent to the old one, granted by [`to_nat_from_nat`](https://github.com/vzaliva/helix/blob/5def0699057c293625990b12e19a4d141ee46129/coq/DSigmaHCOL/NType.v#L51).
  + The new form appears more "obvious": there are only so many `nat`s to be translated _to_, while translating a `nat` to `NType` is more vague.