### PR TITLE
Stop assuming a `R -> err Float` function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
     def BUILD_IF_BRANCH = ['master','develop']
  */
 
-def BUILD_IF_BRANCH = ['master','bounds']
+def BUILD_IF_BRANCH = ['master','bounds', 'no_floatOfR']
 
 pipeline {
     agent { 

--- a/coq/DSigmaHCOL/DHCOLTypeTranslator.v
+++ b/coq/DSigmaHCOL/DHCOLTypeTranslator.v
@@ -95,30 +95,7 @@ Module MDHCOLTypeTranslator
       translateCTypeConst_heq_CType :
       forall x x', translateCTypeConst x = inr x' ->
               heq_CType x x';
-      (*
-      (* Partial mapping of [CT.t] values to [CT'.t] *)
-      translateCTypeValue : CT.t -> err CT'.t ;
-
-      translateCTypeValue_proper : Proper ((=) ==> (=)) translateCTypeValue;
-
-      (* Value mapping should result in "equal" values *)
-      translateCTypeValue_heq_CType :
-      forall x x', translateCTypeValue x = inr x' -> heq_CType x x';
-
-      (* Ensure [translateCTypeConst] is compatible with [translateCTypeValue] *)
-      translateCTypeConst_translateCTypeValue_compat :
-      forall x x', translateCTypeConst x = inr x' ->
-              translateCTypeValue x = inr x';
-       *)
     }.
-
-  (*
-  Class CTranslationOp_strict `{CTO : CTranslationOp} :=
-    {
-      heq_CType_translateCTypeValue :
-      forall x x', heq_CType x x' -> translateCTypeValue x = inr x';
-    }.
-   *)
 
   (* TODO: [translateNTypeValue] vs [translateNTypeConst].
      Why even have the first one? *)
@@ -1266,33 +1243,6 @@ Module MDHCOLTypeTranslator
   Section TranslationOp_Correctness.
 
     Context `{NTO : NTranslationOp} `{CTO : CTranslationOp}.
-
-    (*
-    Fact heq_CType_zero_one_wd:
-      heq_CType CT.CTypeZero CT'.CTypeZero /\
-      heq_CType CT.CTypeOne CT'.CTypeOne.
-    Proof.
-      split;
-        apply translateCTypeValue_heq_CType;
-        apply translateCTypeConst_translateCTypeValue_compat;
-        cbv.
-      -
-        break_if.
-        + reflexivity.
-        + break_if; clear -n; contradict n; reflexivity.
-      -
-        break_if.
-        +
-          clear -e.
-          symmetry in e.
-          contradict e.
-          apply CT.CTypeZeroOneApart.
-        +
-          break_if.
-          * reflexivity.
-          * clear -n0; contradict n0; reflexivity.
-    Qed.
-     *)
 
     Lemma translate_mem_block_heq_mem_block
           (m:L.mem_block) (m':L'.mem_block):

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -1681,9 +1681,9 @@ Section RHCOL_to_FHCOL_numerical.
     repeat constructor.
   Qed.
 
-  Local Fact trivial_RF_translateCTypeValue_heq_CType :
+  Local Fact trivial_RF_translateCTypeConst_heq_CType :
     ∀ (x : R) (x' : Bits.binary64),
-      RHCOLtoFHCOL.translateCTypeValue x = inr x' →
+      RHCOLtoFHCOL.translateCTypeConst x = inr x' →
       @RHCOLtoFHCOL.heq_CType trivial_RF_CHE x x'.
   Proof.
     repeat constructor.
@@ -1691,10 +1691,7 @@ Section RHCOL_to_FHCOL_numerical.
 
   Local Definition trivial_RF_CTO : @RHCOLtoFHCOL.CTranslationOp trivial_RF_CHE :=
     {|
-      RHCOLtoFHCOL.translateCTypeValue := @RHCOLtoFHCOL.translateCTypeValue _ RF_CTO;
-      RHCOLtoFHCOL.translateCTypeValue_heq_CType := trivial_RF_translateCTypeValue_heq_CType;
-      RHCOLtoFHCOL.translateCTypeConst_translateCTypeValue_compat :=
-      @RHCOLtoFHCOL.translateCTypeConst_translateCTypeValue_compat _ RF_CTO;
+      RHCOLtoFHCOL.translateCTypeConst_heq_CType := trivial_RF_translateCTypeConst_heq_CType;
     |}.
 
   Definition RF_Structural_Semantic_Preservation :=
@@ -1710,7 +1707,7 @@ Section RHCOL_to_FHCOL_numerical.
     :
     RHCOLtoFHCOL.translate dynwin_RHCOL = inr dynwin_FHCOL ->
 
-    RHCOLtoFHCOL.translateEvalContext dynwin_R_σ = inr dynwin_F_σ ->
+    RHCOLtoFHCOL.heq_evalContext dynwin_R_σ dynwin_F_σ ->
 
     hopt (herr (@RHCOLtoFHCOL.evalNExpr_closure_trace_equiv RF_NHE trivial_RF_CHE))
          (RHCOLEval.intervalEvalDSHOperator_σ

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -2143,11 +2143,6 @@ Section TopLevel.
     `{RF_CHE : RHCOLtoFHCOL.CTranslation_heq}
     `{RF_CTO : @RHCOLtoFHCOL.CTranslationOp RF_CHE}.
 
-  (* TODO: removing this was kind of a big deal *)
-  (* We assuming that there is an injection of CType to Reals *)
-  (* Hypothesis RHCOLtoRHCOL_total :
-     forall c, exists r, RHCOLtoRHCOL.translateCTypeValue c ≡ inr r. *)
-
   (*
   (* User can specify optional constraints on input values and
      arguments. For example, for cyber-physical system it could

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -2503,12 +2503,34 @@ Section TopLevel.
       apply trivial_RF_CTO.
     }
     {
-      eapply @RHCOLtoFHCOL.translateEvalContext_same_indices with (CTO:=trivial_RF_CTO).
-      assumption.
+      clear - CRE.
+      induction CRE.
+      -
+        constructor.
+      -
+        constructor;
+          [| apply IHCRE].
+        unfold RHCOLtoFHCOL.heq_evalContextElem in *.
+        repeat break_let; subst.
+        repeat constructor.
+        intuition.
+        destruct H as [_ D].
+        invc D; repeat constructor; assumption.
     }
     {
-      eapply @RHCOLtoFHCOL.translate_runtime_memory_same_indices with (CTO:=trivial_RF_CTO).
-      assumption.
+      clear - CRM.
+      generalize dependent (dynwin_R_memory a x).
+      clear.
+      intros dynwin_R_memory M.
+
+      intros k.
+      specialize (M k).
+      invc M; constructor.
+
+      intros k'.
+      specialize (H1 k').
+      invc H1; constructor.
+      constructor.
     }
     {
       now eapply @RHCOLtoFHCOL_NExpr_closure_trace_equiv.

--- a/coq/DynWin/DynWinProofs.v
+++ b/coq/DynWin/DynWinProofs.v
@@ -2217,11 +2217,9 @@ Section TopLevel.
         (* Compile -> RHCOL -> FHCOL *)
         RHCOLtoFHCOL.translate dynwin_RHCOL = inr dynwin_FHCOL ->
 
-        (* Compile memory *)
-        RHCOLtoFHCOL.translate_runtime_memory (dynwin_R_memory a x) = inr dynwin_F_memory ->
-
-        (* compile σ *)
-        RHCOLtoFHCOL.translateEvalContext dynwin_R_σ = inr dynwin_F_σ ->
+        (* Equivalent inputs *)
+        RHCOLtoFHCOL.heq_memory (dynwin_R_memory a x) dynwin_F_memory ->
+        RHCOLtoFHCOL.heq_evalContext dynwin_R_σ dynwin_F_σ ->
 
         forall a_rmem x_rmem,
           RHCOLEval.memory_lookup (dynwin_R_memory a x) dynwin_a_addr = Some a_rmem ->


### PR DESCRIPTION
The primary goal of this pull request is in 128afc8c1f37b4f92b3dbd40e232641e2f82cdd1.
The assumption that there exists a "reasonable" `R -> err Float` function was unnecessary, complicated the statement, and possibly even introduced some decidability issues.
Such an assumption is now removed, uses of the `R -> err Float` function are replaced with a heterogeneous equivalence _relation_.